### PR TITLE
Move extra tools from main Brioche repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,17 @@ jobs:
             runs_on: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             tools_target: x86_64-unknown-linux-musl
+            packed_exec: brioche-packed-userland-exec
           - name: x86_64-macos
             runs_on: macos-14
             target: x86_64-apple-darwin
             tools_target: x86_64-apple-darwin
+            packed_exec: brioche-packed-plain-exec
           - name: aarch64-macos
             runs_on: macos-14
             target: aarch64-apple-darwin
             tools_target: aarch64-apple-darwin
+            packed_exec: brioche-packed-plain-exec
 
     runs-on: ${{ matrix.platform.runs_on }}
     steps:
@@ -71,9 +74,18 @@ jobs:
           TOOLS_TARGET: ${{ matrix.platform.tools_target }}
       - name: Build Brioche runtime utils
         run: |
+          cargo build \
+            --all \
+            --bin brioche-ld \
+            --release \
+            --target="$TOOLS_TARGET"
+
           cargo +"$NIGHTLY_TOOLCHAIN" build \
             --all \
-            --bins \
+            --bin brioche-packed-plain-exec \
+            --bin brioche-packed-userland-exec \
+            --bin runnable \
+            --bin start-runnable \
             --profile=release-tiny \
             --target="$TOOLS_TARGET" \
             -Z 'build-std=std,panic_abort' \
@@ -85,11 +97,16 @@ jobs:
           mkdir -p "artifacts/brioche/$PLATFORM/"
           mkdir -p "artifacts/brioche-runtime-utils/$PLATFORM/bin/"
           cp \
+            "target/$TOOLS_TARGET/release/brioche-ld" \
+            "target/$TOOLS_TARGET/release-tiny/brioche-packed-plain-exec" \
+            "target/$TOOLS_TARGET/release-tiny/brioche-packed-userland-exec" \
             "target/$TOOLS_TARGET/release-tiny/runnable" \
             "target/$TOOLS_TARGET/release-tiny/start-runnable" \
             "artifacts/brioche-runtime-utils/$PLATFORM/bin/"
-          (cd "artifacts/brioche-runtime-utils/$PLATFORM/" && tar --zstd -cf "../../brioche/$PLATFORM/brioche-runtime-utils.tar.zstd" .)
 
+          cp "artifacts/brioche-runtime-utils/$PLATFORM/bin/$PACKED_EXEC" "artifacts/brioche-runtime-utils/$PLATFORM/bin/brioche-packed-exec"
+
+          (cd "artifacts/brioche-runtime-utils/$PLATFORM/" && tar --zstd -cf "../../brioche/$PLATFORM/brioche-runtime-utils.tar.zstd" .)
 
           if command -v tree &> /dev/null; then
             tree --du -h artifacts/brioche-runtime-utils

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           cargo build \
             --all \
             --bin brioche-ld \
+            --bin brioche-packer \
             --release \
             --target="$TOOLS_TARGET"
 
@@ -98,6 +99,7 @@ jobs:
           mkdir -p "artifacts/brioche-runtime-utils/$PLATFORM/bin/"
           cp \
             "target/$TOOLS_TARGET/release/brioche-ld" \
+            "target/$TOOLS_TARGET/release/brioche-packer" \
             "target/$TOOLS_TARGET/release-tiny/brioche-packed-plain-exec" \
             "target/$TOOLS_TARGET/release-tiny/brioche-packed-userland-exec" \
             "target/$TOOLS_TARGET/release-tiny/runnable" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +137,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
 dependencies = [
  "virtue",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "blake3"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "brioche-ld"
+version = "0.1.1"
+dependencies = [
+ "brioche-pack",
+ "bstr",
+ "goblin 0.7.1",
+ "thiserror",
+]
+
+[[package]]
+name = "brioche-pack"
+version = "0.1.1"
+source = "git+https://github.com/brioche-dev/brioche.git#d82dfbff5f34f71e037466b11d3dde7ba75257f0"
+dependencies = [
+ "bincode",
+ "blake3",
+ "bstr",
+ "clap",
+ "goblin 0.7.1",
+ "pathdiff",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "tick-encoding",
+ "ulid",
+]
+
+[[package]]
+name = "brioche-packed-plain-exec"
+version = "0.1.1"
+dependencies = [
+ "brioche-pack",
+ "bstr",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "brioche-packed-userland-exec"
+version = "0.1.1"
+dependencies = [
+ "bincode",
+ "brioche-pack",
+ "bstr",
+ "cfg-if",
+ "libc",
+ "thiserror",
+ "userland-execve",
 ]
 
 [[package]]
@@ -243,6 +326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,10 +405,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "goblin"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.11.0",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.12.0",
+]
 
 [[package]]
 name = "hashbrown"
@@ -457,6 +581,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,16 +628,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -520,6 +673,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -564,6 +747,46 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive 0.11.1",
+]
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive 0.12.0",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde"
@@ -774,10 +997,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
+dependencies = [
+ "getrandom",
+ "rand",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "userland-execve"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5394ca2e759920eefe2b20fc111d6e612cc2d71a47f9449745f93af88b61ba"
+dependencies = [
+ "goblin 0.8.2",
+ "nix",
+]
 
 [[package]]
 name = "utf8parse"
@@ -796,6 +1040,12 @@ name = "virtue"
 version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -850,6 +1100,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "brioche-packer"
+version = "0.1.0"
+dependencies = [
+ "brioche-pack",
+ "clap",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "bstr"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/brioche-ld",
     "crates/brioche-packed-plain-exec",
     "crates/brioche-packed-userland-exec",
+    "crates/brioche-packer",
     "crates/runnable",
     "crates/runnable-core",
     "crates/start-runnable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,16 @@
 [workspace]
-members = [ "crates/runnable-core","crates/start-runnable", "crates/runnable"]
 resolver = "2"
+members = [
+    "crates/brioche-ld",
+    "crates/brioche-packed-plain-exec",
+    "crates/brioche-packed-userland-exec",
+    "crates/runnable",
+    "crates/runnable-core",
+    "crates/start-runnable",
+]
+
+[workspace.dependencies]
+brioche-pack = { git = "https://github.com/brioche-dev/brioche.git", default-features = false }
 
 [profile.release-tiny]
 inherits = "release"

--- a/crates/brioche-ld/Cargo.toml
+++ b/crates/brioche-ld/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "brioche-ld"
+version = "0.1.1"
+edition = "2021"
+
+[dependencies]
+brioche-pack = { workspace = true }
+bstr = "1.8.0"
+goblin = "0.7.1"
+thiserror = "1.0.51"

--- a/crates/brioche-ld/src/main.rs
+++ b/crates/brioche-ld/src/main.rs
@@ -1,0 +1,154 @@
+use std::{path::PathBuf, process::ExitCode};
+
+use bstr::ByteSlice as _;
+
+enum Mode {
+    AutowrapEnabled {
+        resource_dir: PathBuf,
+        all_resource_dirs: Vec<PathBuf>,
+    },
+    AutowrapDisabled,
+}
+
+fn main() -> ExitCode {
+    let result = run();
+
+    match result {
+        Ok(exit_code) => exit_code,
+        Err(err) => {
+            eprintln!("{:#}", err);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<ExitCode, LdError> {
+    let current_exe = std::env::current_exe().map_err(LdError::FailedToGetCurrentExe)?;
+    let current_exe_dir = current_exe
+        .parent()
+        .ok_or_else(|| LdError::FailedToGetCurrentExeDir)?;
+    let current_exe_parent_dir = current_exe_dir
+        .parent()
+        .ok_or_else(|| LdError::FailedToGetCurrentExeDir)?;
+    let ld_resource_dir = current_exe_parent_dir.join("libexec").join("brioche-ld");
+    if !ld_resource_dir.is_dir() {
+        return Err(LdError::LinkerResourceDirNotFound(ld_resource_dir));
+    }
+
+    let linker = ld_resource_dir.join("ld");
+    let packed_path = ld_resource_dir.join("brioche-packed");
+
+    let mut output_path = PathBuf::from("a.out");
+    let mut library_search_paths = vec![];
+    let mut input_paths = vec![];
+
+    let mut args = std::env::args_os().skip(1);
+    while let Some(arg) = args.next() {
+        let arg = <[u8]>::from_os_str(&arg).ok_or_else(|| LdError::InvalidArg)?;
+        let arg = bstr::BStr::new(arg);
+
+        if &**arg == b"-o" {
+            let output = args.next().ok_or_else(|| LdError::InvalidArg)?;
+            output_path = PathBuf::from(output);
+        } else if let Some(output) = arg.strip_prefix(b"-o") {
+            let output = output.to_path().map_err(|_| LdError::InvalidPath)?;
+            output_path = output.to_owned();
+        } else if &**arg == b"-L" {
+            let lib_path = args.next().ok_or_else(|| LdError::InvalidArg)?;
+            library_search_paths.push(PathBuf::from(lib_path));
+        } else if let Some(lib_path) = arg.strip_prefix(b"-L") {
+            let lib_path = lib_path.to_path().map_err(|_| LdError::InvalidPath)?;
+            library_search_paths.push(lib_path.to_owned());
+        } else if arg.starts_with(b"-") {
+            // Ignore other arguments
+        } else {
+            let input_path = arg.to_path().map_err(|_| LdError::InvalidPath)?;
+            input_paths.push(input_path.to_owned());
+        }
+    }
+
+    // Determine whether we will wrap the resulting binary or not. We do this
+    // before running the command so we can bail early if the resource dir
+    // cannot be found.
+    let autowrap_mode = match std::env::var("BRIOCHE_LD_AUTOWRAP").as_deref() {
+        Ok("false") => Mode::AutowrapDisabled,
+        _ => {
+            let resource_dir = brioche_pack::find_output_resource_dir(&output_path)
+                .map_err(LdError::ResourceDirError)?;
+            let all_resource_dirs = brioche_pack::find_resource_dirs(&current_exe, true)
+                .map_err(LdError::ResourceDirError)?;
+            Mode::AutowrapEnabled {
+                resource_dir,
+                all_resource_dirs,
+            }
+        }
+    };
+    let skip_unknown_libs = matches!(
+        std::env::var("BRIOCHE_LD_AUTOWRAP_SKIP_UNKNOWN_LIBS").as_deref(),
+        Ok("true")
+    );
+
+    let mut command = std::process::Command::new(linker);
+    command.args(std::env::args_os().skip(1));
+    let status = command.status()?;
+
+    if !status.success() {
+        let exit_code = status
+            .code()
+            .and_then(|code| u8::try_from(code).ok())
+            .map(ExitCode::from)
+            .unwrap_or(ExitCode::FAILURE);
+        return Ok(exit_code);
+    }
+
+    match autowrap_mode {
+        Mode::AutowrapEnabled {
+            resource_dir,
+            all_resource_dirs,
+        } => {
+            brioche_pack::autowrap::autowrap(brioche_pack::autowrap::AutowrapOptions {
+                program_path: &output_path,
+                packed_exec_path: &packed_path,
+                resource_dir: &resource_dir,
+                all_resource_dirs: &all_resource_dirs,
+                sysroot: &ld_resource_dir,
+                library_search_paths: &library_search_paths,
+                input_paths: &input_paths,
+                skip_libs: &[],
+                skip_unknown_libs,
+                runtime_library_dirs: &[],
+            })?;
+        }
+        Mode::AutowrapDisabled => {
+            // We already wrote the binary, so nothing to do
+        }
+    };
+
+    Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum LdError {
+    #[error("error wrapping binary: {0}")]
+    AutowrapError(#[from] brioche_pack::autowrap::AutowrapError),
+    #[error("invalid arg")]
+    InvalidArg,
+    #[error("invalid path")]
+    InvalidPath,
+    #[error("failed to find current executable: {0}")]
+    FailedToGetCurrentExe(#[source] std::io::Error),
+    #[error("failed to get directory containing current executable")]
+    FailedToGetCurrentExeDir,
+    #[error("brioche-ld resource dir not found (expected to be at {0})")]
+    LinkerResourceDirNotFound(PathBuf),
+    #[error("{0}")]
+    IoError(#[from] std::io::Error),
+    #[error("{0}")]
+    GoblinError(#[from] goblin::error::Error),
+    #[error("error when finding resource dir")]
+    ResourceDirError(#[from] brioche_pack::PackResourceDirError),
+    #[error("error writing packed program")]
+    InjectPackError(#[from] brioche_pack::InjectPackError),
+    #[error("error adding blob: {0}")]
+    AddBlobError(#[from] brioche_pack::resources::AddBlobError),
+}

--- a/crates/brioche-ld/src/main.rs
+++ b/crates/brioche-ld/src/main.rs
@@ -52,7 +52,7 @@ fn run() -> Result<ExitCode, LdError> {
             output_path = PathBuf::from(output);
         } else if let Some(output) = arg.strip_prefix(b"-o") {
             let output = output.to_path().map_err(|_| LdError::InvalidPath)?;
-            output_path = output.to_owned();
+            output.clone_into(&mut output_path);
         } else if &**arg == b"-L" {
             let lib_path = args.next().ok_or_else(|| LdError::InvalidArg)?;
             library_search_paths.push(PathBuf::from(lib_path));

--- a/crates/brioche-packed-plain-exec/Cargo.toml
+++ b/crates/brioche-packed-plain-exec/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "brioche-packed-plain-exec"
+version = "0.1.1"
+edition = "2021"
+
+[dependencies]
+brioche-pack = { workspace = true }
+bstr = "1.8.0"
+libc = "0.2.151"
+thiserror = "1.0.51"

--- a/crates/brioche-packed-plain-exec/src/main.rs
+++ b/crates/brioche-packed-plain-exec/src/main.rs
@@ -1,0 +1,156 @@
+use std::{os::unix::process::CommandExt as _, process::ExitCode};
+
+use bstr::ByteSlice as _;
+
+const BRIOCHE_PACKED_ERROR: u8 = 121;
+
+pub fn main() -> ExitCode {
+    let result = run();
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("brioche-packed error: {err}");
+            ExitCode::from(BRIOCHE_PACKED_ERROR)
+        }
+    }
+}
+
+fn run() -> Result<(), PackedError> {
+    let path = std::env::current_exe()?;
+    let parent_path = path.parent().ok_or(PackedError::InvalidPath)?;
+    let resource_dirs = brioche_pack::find_resource_dirs(&path, true)?;
+    let mut program = std::fs::File::open(&path)?;
+    let pack = brioche_pack::extract_pack(&mut program)?;
+
+    match pack {
+        brioche_pack::Pack::LdLinux {
+            program,
+            interpreter,
+            library_dirs,
+            runtime_library_dirs,
+        } => {
+            let mut args = std::env::args_os();
+
+            let interpreter = interpreter
+                .to_path()
+                .map_err(|_| PackedError::InvalidPath)?;
+            let interpreter = brioche_pack::find_in_resource_dirs(&resource_dirs, interpreter)
+                .ok_or(PackedError::ResourceNotFound)?;
+            let mut command = std::process::Command::new(interpreter);
+
+            let mut resolved_library_dirs = vec![];
+
+            for library_dir in &runtime_library_dirs {
+                let library_dir = library_dir
+                    .to_path()
+                    .map_err(|_| PackedError::InvalidPath)?;
+                let resolved_library_dir = parent_path.join(library_dir);
+                resolved_library_dirs.push(resolved_library_dir);
+            }
+
+            for library_dir in &library_dirs {
+                let library_dir = library_dir
+                    .to_path()
+                    .map_err(|_| PackedError::InvalidPath)?;
+                let library_dir = brioche_pack::find_in_resource_dirs(&resource_dirs, library_dir)
+                    .ok_or(PackedError::ResourceNotFound)?;
+                resolved_library_dirs.push(library_dir);
+            }
+
+            if !resolved_library_dirs.is_empty() {
+                let mut ld_library_path = bstr::BString::default();
+                for (n, library_dir) in resolved_library_dirs.iter().enumerate() {
+                    if n > 0 {
+                        ld_library_path.push(b':');
+                    }
+
+                    let path =
+                        <[u8]>::from_path(library_dir).ok_or_else(|| PackedError::InvalidPath)?;
+                    ld_library_path.extend(path);
+                }
+
+                if let Some(env_library_path) = std::env::var_os("LD_LIBRARY_PATH") {
+                    let env_library_path = <[u8]>::from_os_str(&env_library_path)
+                        .ok_or_else(|| PackedError::InvalidPath)?;
+                    if !env_library_path.is_empty() {
+                        ld_library_path.push(b':');
+                        ld_library_path.extend(env_library_path);
+                    }
+                }
+
+                command.arg("--library-path");
+
+                let ld_library_path = ld_library_path
+                    .to_os_str()
+                    .map_err(|_| PackedError::InvalidPath)?;
+                command.arg(ld_library_path);
+            }
+
+            if let Some(arg0) = args.next() {
+                command.arg("--argv0");
+                command.arg(arg0);
+            }
+
+            let program = program.to_path().map_err(|_| PackedError::InvalidPath)?;
+            let program = brioche_pack::find_in_resource_dirs(&resource_dirs, program)
+                .ok_or(PackedError::ResourceNotFound)?;
+            let program = program.canonicalize()?;
+            command.arg(program);
+
+            command.args(args);
+
+            let error = command.exec();
+            Err(PackedError::IoError(error))
+        }
+        brioche_pack::Pack::Static { .. } => {
+            unimplemented!("execution of a static executable");
+        }
+        brioche_pack::Pack::Metadata { .. } => {
+            unimplemented!("execution of a metadata pack");
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum PackedError {
+    IoError(#[from] std::io::Error),
+    ExtractPackError(#[from] brioche_pack::ExtractPackError),
+    PackResourceDirError(#[from] brioche_pack::PackResourceDirError),
+    ResourceNotFound,
+    InvalidPath,
+}
+
+impl std::fmt::Display for PackedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(error_summary(self))
+    }
+}
+
+fn error_summary(error: &PackedError) -> &'static str {
+    match error {
+        PackedError::IoError(_) => "io error",
+        PackedError::ExtractPackError(error) => match error {
+            brioche_pack::ExtractPackError::ReadPackedProgramError(_) => {
+                "failed to read packed program: io error"
+            }
+            brioche_pack::ExtractPackError::MarkerNotFound => {
+                "marker not found at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::MalformedMarker => {
+                "malformed marker at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::InvalidPack(_) => "failed to parse pack: bincode error",
+        },
+        PackedError::PackResourceDirError(error) => match error {
+            brioche_pack::PackResourceDirError::NotFound => "brioche pack resource dir not found",
+            brioche_pack::PackResourceDirError::DepthLimitReached => {
+                "reached depth limit while searching for brioche pack resource dir"
+            }
+            brioche_pack::PackResourceDirError::IoError(_) => {
+                "error while searching for brioche pack resource dir: io error"
+            }
+        },
+        PackedError::ResourceNotFound => "resource not found",
+        PackedError::InvalidPath => "invalid path",
+    }
+}

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "brioche-packed-userland-exec"
+version = "0.1.1"
+edition = "2021"
+
+[dependencies]
+bincode = "2.0.0-rc.3"
+brioche-pack = { workspace = true }
+bstr = "1.8.0"
+cfg-if = "1.0.0"
+libc = "0.2.151"
+thiserror = "1.0.51"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+userland-execve = "0.2.0"

--- a/crates/brioche-packed-userland-exec/src/linux.rs
+++ b/crates/brioche-packed-userland-exec/src/linux.rs
@@ -1,0 +1,199 @@
+#![cfg(target_os = "linux")]
+
+use std::ffi::{CStr, CString};
+
+use bstr::ByteSlice as _;
+
+const BRIOCHE_PACKED_ERROR: u8 = 121;
+
+extern "C" {
+    static environ: *const *const libc::c_char;
+}
+
+#[inline(always)]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn entrypoint(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int {
+    let mut args = vec![];
+    let mut env_vars = vec![];
+
+    let argc: usize = argc.try_into().unwrap_or(0);
+    for n in 0..argc {
+        let arg = unsafe { *argv.add(n) };
+
+        if arg.is_null() {
+            break;
+        }
+
+        let arg = unsafe { CStr::from_ptr(arg) };
+        args.push(arg);
+    }
+
+    for n in 0.. {
+        let var = unsafe { *environ.add(n) };
+
+        if var.is_null() {
+            break;
+        }
+
+        let var = unsafe { CStr::from_ptr(var) };
+        env_vars.push(var);
+    }
+
+    let result = run(&args, &env_vars);
+    match result {
+        Ok(()) => libc::EXIT_SUCCESS,
+        Err(err) => {
+            eprintln!("brioche-packed error: {err}");
+            BRIOCHE_PACKED_ERROR.into()
+        }
+    }
+}
+
+fn run(args: &[&CStr], env_vars: &[&CStr]) -> Result<(), PackedError> {
+    let path = std::env::current_exe()?;
+    let parent_path = path.parent().ok_or(PackedError::InvalidPath)?;
+    let resource_dirs = brioche_pack::find_resource_dirs(&path, true)?;
+    let mut program = std::fs::File::open(&path)?;
+    let pack = brioche_pack::extract_pack(&mut program)?;
+
+    match pack {
+        brioche_pack::Pack::LdLinux {
+            program,
+            interpreter,
+            library_dirs,
+            runtime_library_dirs,
+        } => {
+            let interpreter = interpreter
+                .to_path()
+                .map_err(|_| PackedError::InvalidPath)?;
+            let interpreter = brioche_pack::find_in_resource_dirs(&resource_dirs, interpreter)
+                .ok_or(PackedError::ResourceNotFound)?;
+
+            let program = program.to_path().map_err(|_| PackedError::InvalidPath)?;
+            let program = brioche_pack::find_in_resource_dirs(&resource_dirs, program)
+                .ok_or(PackedError::ResourceNotFound)?;
+            let program = program.canonicalize()?;
+            let mut exec = userland_execve::ExecOptions::new(&interpreter);
+
+            let interpreter =
+                <[u8]>::from_path(&interpreter).ok_or_else(|| PackedError::InvalidPath)?;
+            let interpreter = CString::new(interpreter).map_err(|_| PackedError::InvalidPath)?;
+
+            let mut resolved_library_dirs = vec![];
+
+            for library_dir in &runtime_library_dirs {
+                let library_dir = library_dir
+                    .to_path()
+                    .map_err(|_| PackedError::InvalidPath)?;
+                let resolved_library_dir = parent_path.join(library_dir);
+                resolved_library_dirs.push(resolved_library_dir);
+            }
+
+            for library_dir in &library_dirs {
+                let library_dir = library_dir
+                    .to_path()
+                    .map_err(|_| PackedError::InvalidPath)?;
+                let library_dir = brioche_pack::find_in_resource_dirs(&resource_dirs, library_dir)
+                    .ok_or(PackedError::ResourceNotFound)?;
+                resolved_library_dirs.push(library_dir);
+            }
+
+            // Add argv0
+            exec.arg(interpreter);
+
+            if !resolved_library_dirs.is_empty() {
+                let mut ld_library_path = bstr::BString::default();
+                for (n, library_dir) in resolved_library_dirs.iter().enumerate() {
+                    if n > 0 {
+                        ld_library_path.push(b':');
+                    }
+
+                    let path =
+                        <[u8]>::from_path(library_dir).ok_or_else(|| PackedError::InvalidPath)?;
+                    ld_library_path.extend(path);
+                }
+
+                if let Some(env_library_path) = std::env::var_os("LD_LIBRARY_PATH") {
+                    let env_library_path = <[u8]>::from_os_str(&env_library_path)
+                        .ok_or_else(|| PackedError::InvalidPath)?;
+                    if !env_library_path.is_empty() {
+                        ld_library_path.push(b':');
+                        ld_library_path.extend(env_library_path);
+                    }
+                }
+
+                exec.arg(CStr::from_bytes_with_nul(b"--library-path\0").unwrap());
+
+                let ld_library_path =
+                    CString::new(ld_library_path).map_err(|_| PackedError::InvalidPath)?;
+                exec.arg(ld_library_path);
+            }
+
+            let mut args = args.iter();
+            if let Some(arg0) = args.next() {
+                exec.arg(CStr::from_bytes_with_nul(b"--argv0\0").unwrap());
+                exec.arg(arg0);
+            }
+
+            let program = <[u8]>::from_path(&program).ok_or_else(|| PackedError::InvalidPath)?;
+            let program = CString::new(program).map_err(|_| PackedError::InvalidPath)?;
+            exec.arg(program);
+
+            exec.args(args);
+
+            exec.env_pairs(env_vars);
+
+            userland_execve::exec_with_options(exec);
+        }
+        brioche_pack::Pack::Static { .. } => {
+            unimplemented!("execution of a static executable");
+        }
+        brioche_pack::Pack::Metadata { .. } => {
+            unimplemented!("execution of a metadata pack");
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum PackedError {
+    IoError(#[from] std::io::Error),
+    ExtractPackError(#[from] brioche_pack::ExtractPackError),
+    PackResourceDirError(#[from] brioche_pack::PackResourceDirError),
+    InvalidPath,
+    ResourceNotFound,
+}
+
+impl std::fmt::Display for PackedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(error_summary(self))
+    }
+}
+
+fn error_summary(error: &PackedError) -> &'static str {
+    match error {
+        PackedError::IoError(_) => "io error",
+        PackedError::ExtractPackError(error) => match error {
+            brioche_pack::ExtractPackError::ReadPackedProgramError(_) => {
+                "failed to read packed program: io error"
+            }
+            brioche_pack::ExtractPackError::MarkerNotFound => {
+                "marker not found at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::MalformedMarker => {
+                "malformed marker at the end of the packed program"
+            }
+            brioche_pack::ExtractPackError::InvalidPack(_) => "failed to parse pack: bincode error",
+        },
+        PackedError::PackResourceDirError(error) => match error {
+            brioche_pack::PackResourceDirError::NotFound => "brioche pack resource dir not found",
+            brioche_pack::PackResourceDirError::DepthLimitReached => {
+                "reached depth limit while searching for brioche pack resource dir"
+            }
+            brioche_pack::PackResourceDirError::IoError(_) => {
+                "error while searching for brioche pack resource dir: io error"
+            }
+        },
+        PackedError::InvalidPath => "invalid path",
+        PackedError::ResourceNotFound => "resource not found",
+    }
+}

--- a/crates/brioche-packed-userland-exec/src/main.rs
+++ b/crates/brioche-packed-userland-exec/src/main.rs
@@ -1,0 +1,18 @@
+#![cfg_attr(all(target_os = "linux", not(test)), no_main)]
+
+mod linux;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        #[cfg_attr(not(test), no_mangle)]
+        #[allow(clippy::missing_safety_doc)]
+        pub unsafe extern "C" fn main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int {
+            linux::entrypoint(argc, argv)
+        }
+    } else {
+        fn main() {
+            eprintln!("brioche-packed-userland-exec is only supported on Linux");
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/brioche-packer/Cargo.toml
+++ b/crates/brioche-packer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "brioche-packer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+brioche-pack = { workspace = true }
+clap = { version = "4.4.11", features = ["derive"] }
+serde_json = { version = "1.0.108" }
+thiserror = "1.0.51"

--- a/crates/brioche-packer/src/main.rs
+++ b/crates/brioche-packer/src/main.rs
@@ -1,0 +1,141 @@
+use std::{path::PathBuf, process::ExitCode};
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+enum Args {
+    Pack {
+        #[arg(long)]
+        packed: PathBuf,
+        #[arg(long)]
+        output: PathBuf,
+        #[arg(long)]
+        pack: String,
+    },
+    Autowrap {
+        #[arg(long)]
+        packed_exec: PathBuf,
+        #[arg(long)]
+        sysroot: PathBuf,
+        #[arg(short = 'L', long = "lib-dir")]
+        lib_dirs: Vec<PathBuf>,
+        #[arg(long)]
+        skip_lib: Vec<String>,
+        #[arg(long)]
+        skip_unknown_libs: bool,
+        #[arg(long)]
+        runtime_lib_dir: Vec<PathBuf>,
+        programs: Vec<PathBuf>,
+    },
+    Read {
+        program: PathBuf,
+    },
+}
+
+fn main() -> ExitCode {
+    let result = run();
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), PackerError> {
+    let args = Args::parse();
+
+    match args {
+        Args::Pack {
+            packed,
+            output,
+            pack,
+        } => {
+            let pack = serde_json::from_str(&pack).map_err(PackerError::DeserializePack)?;
+
+            std::fs::copy(packed, &output)?;
+            let mut output = std::fs::OpenOptions::new().append(true).open(&output)?;
+
+            brioche_pack::inject_pack(&mut output, &pack)?;
+        }
+        Args::Autowrap {
+            packed_exec,
+            sysroot,
+            lib_dirs,
+            programs,
+            skip_lib,
+            skip_unknown_libs,
+            runtime_lib_dir,
+        } => {
+            for program in &programs {
+                let resource_dir =
+                    brioche_pack::find_output_resource_dir(program).map_err(|error| {
+                        PackerError::PackResourceDir {
+                            program: program.clone(),
+                            error,
+                        }
+                    })?;
+                let all_resource_dirs =
+                    brioche_pack::find_resource_dirs(program, true).map_err(|error| {
+                        PackerError::PackResourceDir {
+                            program: program.clone(),
+                            error,
+                        }
+                    })?;
+                brioche_pack::autowrap::autowrap(brioche_pack::autowrap::AutowrapOptions {
+                    program_path: program,
+                    packed_exec_path: &packed_exec,
+                    resource_dir: &resource_dir,
+                    all_resource_dirs: &all_resource_dirs,
+                    library_search_paths: &lib_dirs,
+                    input_paths: &[],
+                    sysroot: &sysroot,
+                    skip_libs: &skip_lib,
+                    skip_unknown_libs,
+                    runtime_library_dirs: &runtime_lib_dir,
+                })
+                .map_err(|error| PackerError::Autowrap {
+                    program: program.clone(),
+                    error,
+                })?;
+            }
+        }
+        Args::Read { program } => {
+            let mut program = std::fs::File::open(program)?;
+            let pack = brioche_pack::extract_pack(&mut program)?;
+
+            serde_json::to_writer_pretty(std::io::stdout().lock(), &pack)
+                .map_err(PackerError::SerializePack)?;
+            println!();
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+enum PackerError {
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+    #[error("error deserializing pack: {0}")]
+    DeserializePack(#[source] serde_json::Error),
+    #[error("error serializing pack: {0}")]
+    SerializePack(#[source] serde_json::Error),
+    #[error("{0}")]
+    InjectPack(#[from] brioche_pack::InjectPackError),
+    #[error("{0}")]
+    ExtractPack(#[from] brioche_pack::ExtractPackError),
+    #[error("error wrapping {program}: {error}")]
+    PackResourceDir {
+        program: PathBuf,
+        #[source]
+        error: brioche_pack::PackResourceDirError,
+    },
+    #[error("error wrapping {program}: {error}")]
+    Autowrap {
+        program: PathBuf,
+        #[source]
+        error: brioche_pack::autowrap::AutowrapError,
+    },
+}


### PR DESCRIPTION
This PR adds some extra executables to this repo that are currently in the main Brioche repo (as of commit [d82dfbf](https://github.com/brioche-dev/brioche/tree/d82dfbff5f34f71e037466b11d3dde7ba75257f0)). The executables have been moved verbatim along with changes to CI/CD to include them when uploading to S3. The new executables are:

- `brioche-packed-plain-exec`
- `brioche-packed-userland-exec`
- `brioche-packed-exec` (a copy of one of the other two binaries above as a convenience)
- `brioche-ld`
- `brioche-packer` (originally a binary under the `brioche-pack` crate)