### PR TITLE
[Rust] remove unused crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,13 +185,8 @@ dependencies = [
 name = "brioche-packed-userland-exec"
 version = "0.1.1"
 dependencies = [
- "bincode",
- "brioche-pack",
- "brioche-resources",
- "bstr",
  "cfg-if",
  "libc",
- "thiserror",
  "userland-execve",
 ]
 
@@ -639,7 +634,6 @@ name = "runnable-core"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "brioche-pack",
  "brioche-resources",
  "bstr",
  "serde",

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -4,13 +4,8 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-bincode = "2.0.0-rc.3"
-brioche-pack = { workspace = true }
-brioche-resources = { path = "../brioche-resources" }
-bstr = "1.8.0"
 cfg-if = "1.0.0"
 libc = "0.2.151"
-thiserror = "1.0.51"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 userland-execve = "0.2.0"

--- a/crates/runnable-core/Cargo.toml
+++ b/crates/runnable-core/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 bincode = "2.0.0-rc.3"
-brioche-pack = { workspace = true }
 brioche-resources = { path = "../brioche-resources" }
 bstr = "1.9.1"
 serde = { version = "1.0.203", features = ["derive"] }


### PR DESCRIPTION
From cargo udeps:

```bash
unused dependencies:
`brioche-packed-userland-exec v0.1.1 (/Users/jaudiger/Development/git-repositories/jaudiger/brioche-runtime-utils/crates/brioche-packed-userland-exec)`
└─── dependencies
     ├─── "bincode"
     ├─── "brioche-pack"
     ├─── "brioche-resources"
     ├─── "bstr"
     └─── "thiserror"
`runnable-core v0.1.0 (/Users/jaudiger/Development/git-repositories/jaudiger/brioche-runtime-utils/crates/runnable-core)`
└─── dependencies
     └─── "brioche-pack"
```