### PR TITLE
Rename "autowrap" to "autopack" everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "brioche-autowrap"
+name = "brioche-autopack"
 version = "0.1.0"
 dependencies = [
  "brioche-pack",
@@ -188,7 +188,7 @@ dependencies = [
 name = "brioche-ld"
 version = "0.1.1"
 dependencies = [
- "brioche-autowrap",
+ "brioche-autopack",
  "brioche-pack",
  "brioche-resources",
  "bstr",
@@ -244,7 +244,7 @@ dependencies = [
 name = "brioche-packer"
 version = "0.1.0"
 dependencies = [
- "brioche-autowrap",
+ "brioche-autopack",
  "brioche-pack",
  "brioche-resources",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
-members = [ "crates/brioche-autowrap",
+members = [
+    "crates/brioche-autopack",
     "crates/brioche-ld",
     "crates/brioche-packed-plain-exec",
     "crates/brioche-packed-userland-exec",

--- a/crates/brioche-autopack/Cargo.toml
+++ b/crates/brioche-autopack/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "brioche-autowrap"
+name = "brioche-autopack"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/brioche-ld/Cargo.toml
+++ b/crates/brioche-ld/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-brioche-autowrap = { path = "../brioche-autowrap" }
+brioche-autopack = { path = "../brioche-autopack" }
 brioche-pack = { workspace = true }
 brioche-resources = { path = "../brioche-resources" }
 bstr = "1.8.0"

--- a/crates/brioche-packer/Cargo.toml
+++ b/crates/brioche-packer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-brioche-autowrap = { path = "../brioche-autowrap" }
+brioche-autopack = { path = "../brioche-autopack" }
 brioche-pack = { workspace = true }
 brioche-resources = { path = "../brioche-resources" }
 bstr = "1.9.1"


### PR DESCRIPTION
This PR replaces the term "autowrap" with "autopack" everywhere for consistency. I feel this term is more descriptive (we have the `brioche-packer pack` subcommand, and the result is a "packed executable"), and since #5 will lead to a full rebuild of `std` anyway, I feel that this is the best time to make this change.

As far as usage goes, this means the `brioche-autowrap` crate is now `brioche-autopack`, and the `brioche-packer autowrap` subcommand is now `brioche-packer autopack`