### PR TITLE
[Rust] run cargo clippy on nightly

### DIFF
--- a/crates/brioche-autopack/src/lib.rs
+++ b/crates/brioche-autopack/src/lib.rs
@@ -462,7 +462,7 @@ fn autopack_script(
 
     let mut arg = Some(arg).filter(|arg| !arg.is_empty());
     let mut command_name = command_path
-        .split(|c: char| matches!(c, '/' | '\\'))
+        .split(['/', '\\'])
         .last()
         .unwrap_or(command_path);
 


### PR DESCRIPTION
Resolve the following warning from cargo clippy (was run on nightly, the [rule](https://rust-lang.github.io/rust-clippy/master/index.html#manual_pattern_char_comparison) will be part of the next Rust release: 1.80.0)

```bash
warning: this manual char comparison can be written more succinctly
   --> crates/brioche-autopack/src/lib.rs:465:16
    |
465 |         .split(|c: char| matches!(c, '/' | '\\'))
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using an array of `char`: `['/', '\\']`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_pattern_char_comparison
    = note: `#[warn(clippy::manual_pattern_char_comparison)]` on by default

warning: `brioche-autopack` (lib) generated 1 warning (run `cargo clippy --fix --lib -p brioche-autopack` to apply 1 suggestion)
```