### PR TITLE
Adjust relative paths in script env vars

### DIFF
--- a/crates/brioche-autopack/src/lib.rs
+++ b/crates/brioche-autopack/src/lib.rs
@@ -122,6 +122,9 @@ fn relative_template(
                 runnable_core::TemplateComponent::Literal { .. }
                 | runnable_core::TemplateComponent::Resource { .. } => eyre::Ok(component.clone()),
                 runnable_core::TemplateComponent::RelativePath { path } => {
+                    // TODO: Handle path resolution in a cross-platform way.
+                    // This could change based on the host platform
+
                     let path = path
                         .to_path()
                         .with_context(|| format!("failed to parse path {path:?}"))?;

--- a/crates/brioche-packer/src/autopack_template.rs
+++ b/crates/brioche-packer/src/autopack_template.rs
@@ -76,7 +76,9 @@ impl AutopackConfigTemplate {
             .map(|opts| opts.build(ctx, &recipe_path))
             .transpose()?;
         let shared_library = shared_library.map(|opts| opts.build(ctx)).transpose()?;
-        let script = script.map(|opts| opts.build(ctx)).transpose()?;
+        let script = script
+            .map(|opts| opts.build(ctx, &recipe_path))
+            .transpose()?;
         let repack = repack.map(|opts| opts.build());
 
         if self_dependency {
@@ -243,6 +245,7 @@ impl ScriptConfigTemplate {
     fn build(
         self,
         ctx: &AutopackConfigTemplateContext,
+        recipe_path: &Path,
     ) -> eyre::Result<brioche_autopack::ScriptConfig> {
         let Self {
             packed_executable,
@@ -261,6 +264,7 @@ impl ScriptConfigTemplate {
 
         Ok(brioche_autopack::ScriptConfig {
             packed_executable,
+            base_path: Some(recipe_path.into()),
             env,
             clear_env,
         })


### PR DESCRIPTION
This PR tweaks autopacking of scripts when the config adds extra env vars when the script is called. Previously, if the env vars included relative paths, then those paths would be resolved relative to the script's output path, but this was tweaked so it's relative to the top-level recipe path.

Here's the background story for motivation: the `std.toolchain()` recipe includes lots of Perl scripts. When autopacking, we want these scripts to have `PERL5LIB` set with relative paths of `lib/perl5/...`. In code, that would look something like this:

```typescript
std.autopack(toolchain, {
  paths: ["bin/pod2man"], // <-- A Perl script
  // ... other args ...
  scriptConfig: {
    env: {
      PERL5LIB: {
        type: "append",
        separator: ":",
        value: { relativePath: "lib/perl5/5.38.0" },
      },
    },
  },
});
```

Before this PR, `$toolchain/bin/pod2man` would have `PERL5LIB=$toolchain/bin/lib/perl5/5.38.0` (the issue being that the path is resolved relative to `bin` instead of `$toolchain`).

With this PR, the script will instead have `PERL5LIB=$toolchain/lib/perl5/5.38.0`, no more extra `bin/` in the path.