### PR TITLE
Update autopacking to skip shared libs that don't need a pack

### DIFF
--- a/crates/brioche-autopack/src/lib.rs
+++ b/crates/brioche-autopack/src/lib.rs
@@ -48,6 +48,7 @@ pub struct DynamicBinaryConfig {
 #[derive(Debug, Clone)]
 pub struct SharedLibraryConfig {
     pub dynamic_linking: DynamicLinkingConfig,
+    pub allow_empty: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -559,6 +560,10 @@ fn autopack_shared_library(
         })
         .collect::<eyre::Result<Vec<_>>>()?;
     let pack = brioche_pack::Pack::Static { library_dirs };
+
+    if !pack.should_add_to_executable() && !shared_library_config.allow_empty {
+        return Ok(false);
+    }
 
     let file = if source_path == output_path {
         std::fs::OpenOptions::new().append(true).open(output_path)?

--- a/crates/brioche-ld/src/main.rs
+++ b/crates/brioche-ld/src/main.rs
@@ -135,6 +135,7 @@ fn run() -> eyre::Result<ExitCode> {
                 }),
                 shared_library: Some(brioche_autopack::SharedLibraryConfig {
                     dynamic_linking: dynamic_linking_config,
+                    allow_empty: false,
                 }),
                 repack: None,
                 script: None,

--- a/crates/brioche-packer/src/autopack_template.rs
+++ b/crates/brioche-packer/src/autopack_template.rs
@@ -223,6 +223,9 @@ impl DynamicBinaryConfigTemplate {
 pub struct SharedLibraryConfigTemplate {
     #[serde(flatten)]
     dynamic_linking: DynamicLinkingConfigTemplate,
+
+    #[serde(default)]
+    allow_empty: bool,
 }
 
 impl SharedLibraryConfigTemplate {
@@ -230,11 +233,17 @@ impl SharedLibraryConfigTemplate {
         self,
         ctx: &AutopackConfigTemplateContext,
     ) -> eyre::Result<brioche_autopack::SharedLibraryConfig> {
-        let Self { dynamic_linking } = self;
+        let Self {
+            dynamic_linking,
+            allow_empty,
+        } = self;
 
         let dynamic_linking = dynamic_linking.build(ctx)?;
 
-        Ok(brioche_autopack::SharedLibraryConfig { dynamic_linking })
+        Ok(brioche_autopack::SharedLibraryConfig {
+            dynamic_linking,
+            allow_empty,
+        })
     }
 }
 


### PR DESCRIPTION
This PR tweaks the `brioche-packer autopack` subcommand so that, if we try autopacking a shared library but the pack ends up empty (i.e. it has no libraries and therefore doesn't influence the result), then packing will be skipped

For glob patterns, it'll print a "skipped" log message. If the shared library was included explicitly with the `paths` option, then this should become an error (i.e. it failed to pack an "expected" path)

There's also a new `sharedLibrary.allowEmpty` config option which, when set, will add the pack anyway