### PR TITLE
Update runtime utils on the path to packaging CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           cargo build \
             --all \
+            --bin brioche-cc \
             --bin brioche-ld \
             --bin brioche-packer \
             --release \
@@ -96,6 +97,7 @@ jobs:
           mkdir -p "artifacts/brioche/$PLATFORM/"
           mkdir -p "artifacts/brioche-runtime-utils/$PLATFORM/bin/"
           cp \
+            "target/$TOOLS_TARGET/release/brioche-cc" \
             "target/$TOOLS_TARGET/release/brioche-ld" \
             "target/$TOOLS_TARGET/release/brioche-packer" \
             "target/$TOOLS_TARGET/release-tiny/brioche-packed-plain-exec" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "brioche-cc"
+version = "0.1.0"
+dependencies = [
+ "eyre",
+]
+
+[[package]]
 name = "brioche-ld"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/brioche-autopack",
+    "crates/brioche-cc",
     "crates/brioche-ld",
     "crates/brioche-packed-plain-exec",
     "crates/brioche-packed-userland-exec",

--- a/crates/brioche-cc/Cargo.toml
+++ b/crates/brioche-cc/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "brioche-cc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+eyre = "0.6.12"

--- a/crates/brioche-cc/src/main.rs
+++ b/crates/brioche-cc/src/main.rs
@@ -1,0 +1,53 @@
+use std::{os::unix::process::CommandExt as _, process::ExitCode};
+
+use eyre::{Context as _, OptionExt as _};
+
+fn main() -> ExitCode {
+    let result = run();
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("brioche-cc error: {:#}", err);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> eyre::Result<()> {
+    let current_exe = std::env::current_exe().context("failed to get current executable")?;
+    let current_exe_name = current_exe
+        .file_name()
+        .ok_or_eyre("failed to get current executable name")?;
+    let sysroot = current_exe
+        .parent()
+        .and_then(|dir| dir.parent())
+        .ok_or_eyre("failed to get sysroot path")?;
+
+    let mut original_exe_name = current_exe_name.to_owned();
+    original_exe_name.push("-orig");
+    let original_exe = current_exe.with_file_name(&original_exe_name);
+
+    let mut args = std::env::args_os();
+    let arg0 = args.next();
+    let args = args.collect::<Vec<_>>();
+
+    let mut command = std::process::Command::new(&original_exe);
+    if let Some(arg0) = arg0 {
+        command.arg0(&arg0);
+    }
+
+    let has_sysroot_arg = args.iter().any(|arg| {
+        let arg_string = arg.to_string_lossy();
+        arg_string == "--sysroot" || arg_string.starts_with("--sysroot=")
+    });
+
+    if !has_sysroot_arg {
+        command.arg("--sysroot").arg(sysroot);
+    }
+
+    command.args(&args);
+
+    let error = command.exec();
+    panic!("brioche-cc exec error: {error:#}");
+}


### PR DESCRIPTION
This PR makes a few scattered changes to the runtime utils, which are here to help towards adding a CMake package for `brioche-packages`:

- Add new `brioche-packer source-path` subcommand. It takes the path to a [Packed Executable](https://brioche.dev/docs/how-it-works/packed-executables/) and returns the path to the original underlying file (in the case of dynamic binaries, this may be the same as the input path).
- Add `brioche-packer update-source` subcommand. It takes the path to a packed executable and an unpacked executable, and shuffles some stuff around so the packed executable instead uses the new unpacked executable.
- Add new `brioche-cc` utility. This wraps a C compiler similar to how `brioche-ld` wraps a linker. It just adds a `--sysroot` argument if one isn't provided.
  - This was mostly done to help clean up `std.toolchain()` a little bit by replacing a shell script with an actual standalone executable. In the future, there will likely be more that `brioche-cc` can do.

`source-path` and `update-source` together make it possible to do an in-place update to an executable: first you get the "real" executable using `source-path`, copy it and make your changes, then call `update-source` with the changed version. This allows for easily modifying a binary without needing to hand-implement a parser compatible with the Packed Executable metadata format.