### PR TITLE
refactor: update Cargo.toml files to use workspace edition and add linting configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 brioche-pack = { git = "https://github.com/brioche-dev/brioche.git", default-features = false }
 
 [workspace.lints.clippy]
-all = { level = "deny", priority = -1 }
+all = { level = "warn", priority = -1 }
 
 [profile.release-tiny]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace.package]
+edition = "2021"
+
 [workspace]
 resolver = "2"
 members = [
@@ -7,12 +10,16 @@ members = [
     "crates/brioche-packed-plain-exec",
     "crates/brioche-packed-userland-exec",
     "crates/brioche-packer",
-    "crates/brioche-resources", "crates/brioche-strip",
+    "crates/brioche-resources",
+    "crates/brioche-strip",
     "crates/runnable-core",
 ]
 
 [workspace.dependencies]
 brioche-pack = { git = "https://github.com/brioche-dev/brioche.git", default-features = false }
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
 
 [profile.release-tiny]
 inherits = "release"

--- a/crates/brioche-autopack/Cargo.toml
+++ b/crates/brioche-autopack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-autopack"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 brioche-pack = { workspace = true }
@@ -15,3 +15,6 @@ runnable-core = { path = "../runnable-core" }
 serde_json = "1.0.118"
 thiserror = "1.0.61"
 walkdir = "2.5.0"
+
+[lints]
+workspace = true

--- a/crates/brioche-cc/Cargo.toml
+++ b/crates/brioche-cc/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "brioche-cc"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 eyre = "0.6.12"
+
+[lints]
+workspace = true

--- a/crates/brioche-ld/Cargo.toml
+++ b/crates/brioche-ld/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-ld"
 version = "0.1.1"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 brioche-autopack = { path = "../brioche-autopack" }
@@ -10,3 +10,6 @@ brioche-resources = { path = "../brioche-resources" }
 bstr = "1.8.0"
 eyre = "0.6.12"
 thiserror = "1.0.51"
+
+[lints]
+workspace = true

--- a/crates/brioche-packed-plain-exec/Cargo.toml
+++ b/crates/brioche-packed-plain-exec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-packed-plain-exec"
 version = "0.1.1"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 brioche-pack = { workspace = true }
@@ -11,3 +11,6 @@ libc = "0.2.151"
 runnable-core = { path = "../runnable-core" }
 serde_json = "1.0.117"
 thiserror = "1.0.51"
+
+[lints]
+workspace = true

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-packed-userland-exec"
 version = "0.1.1"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 bincode = "2.0.0-rc.3"

--- a/crates/brioche-packer/Cargo.toml
+++ b/crates/brioche-packer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-packer"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 brioche-autopack = { path = "../brioche-autopack" }
@@ -19,3 +19,6 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_json = { version = "1.0.108" }
 serde_with = { version = "3.8.1", features = ["schemars_0_8"] }
 walkdir = "2.5.0"
+
+[lints]
+workspace = true

--- a/crates/brioche-resources/Cargo.toml
+++ b/crates/brioche-resources/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-resources"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 blake3 = "1.5.1"
@@ -12,3 +12,6 @@ thiserror = "1.0.61"
 tick-encoding = "0.1.2"
 ulid = "1.1.2"
 walkdir = "2.5.0"
+
+[lints]
+workspace = true

--- a/crates/brioche-strip/Cargo.toml
+++ b/crates/brioche-strip/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "brioche-strip"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 brioche-autopack = { path = "../brioche-autopack" }
@@ -12,3 +12,6 @@ eyre = "0.6.12"
 tempfile = "3.14.0"
 thiserror = "1.0.51"
 ulid = "1.1.3"
+
+[lints]
+workspace = true

--- a/crates/runnable-core/Cargo.toml
+++ b/crates/runnable-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "runnable-core"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 bincode = "2.0.0-rc.3"
@@ -12,3 +12,6 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_with = { version = "3.8.1", features = ["schemars_0_8"] }
 thiserror = "1.0.61"
 tick-encoding = "0.1.2"
+
+[lints]
+workspace = true


### PR DESCRIPTION
This PR prepares for Rust Edition 2024 by refactoring the edition in the main Cargo file.

I also re-factored at root level the settings of cargo clippy without enabling new lint.

What could be done easier in a future with this approach:

- Defining the Rust version at root level
- Enabling new lints