### PR TITLE
feat: update Rust version to 1.84 in Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace.package]
 edition = "2021"
+rust-version = "1.84"
 
 [workspace]
 resolver = "2"

--- a/crates/brioche-autopack/Cargo.toml
+++ b/crates/brioche-autopack/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-autopack"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 brioche-pack = { workspace = true }

--- a/crates/brioche-cc/Cargo.toml
+++ b/crates/brioche-cc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-cc"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 eyre = "0.6.12"

--- a/crates/brioche-ld/Cargo.toml
+++ b/crates/brioche-ld/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-ld"
 version = "0.1.1"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 brioche-autopack = { path = "../brioche-autopack" }

--- a/crates/brioche-packed-plain-exec/Cargo.toml
+++ b/crates/brioche-packed-plain-exec/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-packed-plain-exec"
 version = "0.1.1"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 brioche-pack = { workspace = true }

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-packed-userland-exec"
 version = "0.1.1"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bincode = "2.0.0-rc.3"

--- a/crates/brioche-packer/Cargo.toml
+++ b/crates/brioche-packer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-packer"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 brioche-autopack = { path = "../brioche-autopack" }

--- a/crates/brioche-resources/Cargo.toml
+++ b/crates/brioche-resources/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-resources"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blake3 = "1.5.1"

--- a/crates/brioche-strip/Cargo.toml
+++ b/crates/brioche-strip/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brioche-strip"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 brioche-autopack = { path = "../brioche-autopack" }

--- a/crates/runnable-core/Cargo.toml
+++ b/crates/runnable-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "runnable-core"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bincode = "2.0.0-rc.3"


### PR DESCRIPTION
Set the `rust-version` workspace field to make it easier to update it in the future.