### PR TITLE
Rust 1 85 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ edition = "2024"
 rust-version = "1.85" # To align with the rust-toolchain.toml
 
 [workspace]
-resolver = "3"
 members = [
     "crates/brioche-autopack",
     "crates/brioche-cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace.package]
-edition = "2021"
-rust-version = "1.84"
+edition = "2024"
+rust-version = "1.85" # To align with the rust-toolchain.toml
 
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "crates/brioche-autopack",
     "crates/brioche-cc",

--- a/crates/brioche-packer/Cargo.toml
+++ b/crates/brioche-packer/Cargo.toml
@@ -15,7 +15,7 @@ eyre = "0.6.12"
 globset = "0.4.14"
 goblin = "0.8.2"
 runnable-core = { path = "../runnable-core" }
-schemars = "0.8.21"
+schemars = "0.8.22"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = { version = "1.0.108" }
 serde_with = { version = "3.8.1", features = ["schemars_0_8"] }

--- a/crates/runnable-core/src/encoding.rs
+++ b/crates/runnable-core/src/encoding.rs
@@ -37,7 +37,7 @@ impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for TickEncoded {
         "TickEncoded".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <String as schemars::JsonSchema>::json_schema(gen)
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String as schemars::JsonSchema>::json_schema(generator)
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.84"
+channel = "1.85"
 profile = "default"
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Enable the support of Rust 1.85, and fix a compat issue with schemars (for more detail, see https://github.com/GREsau/schemars/pull/378/files)