### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
             -Z 'build-std-features=panic_immediate_abort'
         env:
           TOOLS_TARGET: ${{ matrix.platform.tools_target }}
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
       - name: Prepare artifact
         run: |
           mkdir -p "artifacts/brioche/$PLATFORM/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       matrix:
         runs_on:
           - ubuntu-22.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04
           - macos-14
     runs-on: ${{ matrix.runs_on }}
     steps:
@@ -36,7 +38,7 @@ jobs:
       - name: Run tests
         run: cargo test --all --release
   build:
-    name: Build artifacts
+    name: Build artifacts [${{ matrix.platform.name }}]
     strategy:
       matrix:
         platform:
@@ -46,14 +48,10 @@ jobs:
             tools_target: x86_64-unknown-linux-musl
             packed_exec: brioche-packed-userland-exec
           - name: aarch64-linux
-            runs_on: ubuntu-22.04
+            runs_on: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             tools_target: aarch64-unknown-linux-musl
             packed_exec: brioche-packed-userland-exec
-            install_deps: |
-              sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
-              echo 'CC=aarch64-linux-gnu-gcc' >> $GITHUB_ENV
-              echo 'CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc' >> $GITHUB_ENV
           - name: x86_64-macos
             runs_on: macos-14
             target: x86_64-apple-darwin
@@ -81,9 +79,6 @@ jobs:
             --component rust-src
         env:
           TOOLS_TARGET: ${{ matrix.platform.tools_target }}
-      - name: Install dependencies
-        if: matrix.platform.install_deps
-        run: ${{ matrix.platform.install_deps }}
       - name: Build Brioche runtime utils
         run: |
           cargo build \
@@ -143,8 +138,6 @@ jobs:
     needs: [check, test, build]
     runs-on: ubuntu-22.04
     steps:
-      - name: Install AWS CLI
-        uses: unfor19/install-aws-cli-action@v1
       - name: Download artifacts (x86_64-linux)
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This PR updates the "CI" GitHub Actions workflow so Linux aarch64 builds run on GitHub's hosted aarch64 runners.

This was done due to the failure seen in [CI#89](https://github.com/brioche-dev/brioche-runtime-utils/actions/runs/14022426598/job/39256100746), where cross-compiling from Linux x86-64 to Linux aarch64 failed for some reason-- switching to a native aarch64 build seemed like the simplest path forward.