### PR TITLE
Update rust version to 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ nursery = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
-similar_names = "allow"
 too_many_lines = "allow"
 
 [profile.release-tiny]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2024"
-rust-version = "1.86" # To align with the rust-toolchain.toml
+rust-version = "1.87" # To align with the rust-toolchain.toml
 
 [workspace]
 members = [

--- a/crates/brioche-autopack/src/lib.rs
+++ b/crates/brioche-autopack/src/lib.rs
@@ -315,8 +315,12 @@ fn autopack_context(config: &AutopackConfig) -> eyre::Result<AutopackContext> {
                 continue;
             }
             Err(error) => {
-                return Err(error)
-                    .with_context(|| format!("failed to read directory {library_path_env_dir:?}"));
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to read directory {}",
+                        library_path_env_dir.display()
+                    )
+                });
             }
         };
         for entry in library_path_env_dir_entries {
@@ -327,10 +331,9 @@ fn autopack_context(config: &AutopackConfig) -> eyre::Result<AutopackContext> {
                 entry.path()
             );
 
-            let entry_path = entry
-                .path()
-                .canonicalize()
-                .with_context(|| format!("failed to canonicalize path {:?}", entry.path()))?;
+            let entry_path = entry.path().canonicalize().with_context(|| {
+                format!("failed to canonicalize path {}", entry.path().display())
+            })?;
             link_dependency_library_paths.push(entry_path);
         }
     }
@@ -344,8 +347,9 @@ fn autopack_context(config: &AutopackConfig) -> eyre::Result<AutopackContext> {
                 continue;
             }
             Err(error) => {
-                return Err(error)
-                    .with_context(|| format!("failed to read directory {path_env_dir:?}"));
+                return Err(error).with_context(|| {
+                    format!("failed to read directory {}", path_env_dir.display())
+                });
             }
         };
         for entry in path_env_dir_entries {
@@ -356,10 +360,9 @@ fn autopack_context(config: &AutopackConfig) -> eyre::Result<AutopackContext> {
                 entry.path()
             );
 
-            let entry_path = entry
-                .path()
-                .canonicalize()
-                .with_context(|| format!("failed to canonicalize path {:?}", entry.path()))?;
+            let entry_path = entry.path().canonicalize().with_context(|| {
+                format!("failed to canonicalize path {}", entry.path().display())
+            })?;
             link_dependency_paths.push(entry_path);
         }
     }
@@ -509,9 +512,18 @@ fn autopack_dynamic_binary(
     try_autopack_dependency(ctx, &interpreter_path, pending_paths)?;
 
     let interpreter_resource_path = add_named_blob_from(ctx, &interpreter_path, None)
-        .with_context(|| format!("failed to add resource for interpreter {interpreter_path:?}"))?;
-    let program_resource_path = add_named_blob_from(ctx, source_path, None)
-        .with_context(|| format!("failed to add resource for program {source_path:?}"))?;
+        .with_context(|| {
+            format!(
+                "failed to add resource for interpreter {}",
+                interpreter_path.display()
+            )
+        })?;
+    let program_resource_path = add_named_blob_from(ctx, source_path, None).with_context(|| {
+        format!(
+            "failed to add resource for program {}",
+            source_path.display()
+        )
+    })?;
 
     let needed_libraries: VecDeque<_> = program_object
         .libraries
@@ -563,14 +575,22 @@ fn autopack_dynamic_binary(
     };
 
     let packed_exec_path = &dynamic_binary_config.packed_executable;
-    let mut packed_exec = std::fs::File::open(packed_exec_path)
-        .with_context(|| format!("failed to open packed executable {packed_exec_path:?}"))?;
+    let mut packed_exec = std::fs::File::open(packed_exec_path).with_context(|| {
+        format!(
+            "failed to open packed executable {}",
+            packed_exec_path.display()
+        )
+    })?;
     let mut output = std::fs::File::create(output_path)
-        .with_context(|| format!("failed to create file {output_path:?}"))?;
-    std::io::copy(&mut packed_exec, &mut output)
-        .with_context(|| format!("failed to copy packed executable to {output_path:?}"))?;
+        .with_context(|| format!("failed to create file {}", output_path.display()))?;
+    std::io::copy(&mut packed_exec, &mut output).with_context(|| {
+        format!(
+            "failed to copy packed executable to {}",
+            output_path.display()
+        )
+    })?;
     brioche_pack::inject_pack(output, &pack)
-        .with_context(|| format!("failed to inject pack into {output_path:?}"))?;
+        .with_context(|| format!("failed to inject pack into {}", output_path.display()))?;
 
     Ok(true)
 }
@@ -776,15 +796,23 @@ fn autopack_script(
     };
 
     let packed_exec_path = &script_config.packed_executable;
-    let mut packed_exec = std::fs::File::open(packed_exec_path)
-        .with_context(|| format!("failed to open packed executable {packed_exec_path:?}"))?;
+    let mut packed_exec = std::fs::File::open(packed_exec_path).with_context(|| {
+        format!(
+            "failed to open packed executable {}",
+            packed_exec_path.display()
+        )
+    })?;
 
     let mut output = std::fs::File::create(output_path)
-        .with_context(|| format!("failed to create file {output_path:?}"))?;
-    std::io::copy(&mut packed_exec, &mut output)
-        .with_context(|| format!("failed to copy packed executable to {output_path:?}"))?;
+        .with_context(|| format!("failed to create file {}", output_path.display()))?;
+    std::io::copy(&mut packed_exec, &mut output).with_context(|| {
+        format!(
+            "failed to copy packed executable to {}",
+            output_path.display()
+        )
+    })?;
     brioche_pack::inject_pack(output, &pack)
-        .with_context(|| format!("failed to inject pack into {output_path:?}"))?;
+        .with_context(|| format!("failed to inject pack into {}", output_path.display()))?;
 
     Ok(true)
 }
@@ -884,7 +912,12 @@ fn collect_all_library_dirs(
             let library_alias = Path::new(&library_name);
             let library_resource_path =
                 add_named_blob_from(ctx, &library_path, Some(library_alias)).with_context(
-                    || format!("failed to add resource for library {library_path:?}"),
+                    || {
+                        format!(
+                            "failed to add resource for library {}",
+                            library_path.display()
+                        )
+                    },
                 )?;
 
             // Add the parent dir to the list of library directories. Note
@@ -1037,7 +1070,7 @@ fn try_autopack_dependency(
     // Get the canonical path of the dependency
     let canonical_path = path
         .canonicalize()
-        .with_context(|| format!("failed to canonicalize path {path:?}"))?;
+        .with_context(|| format!("failed to canonicalize path {}", path.display()))?;
 
     // If the path is pending, then autopack it
     if let Some(path_config) = pending_paths.remove(&canonical_path) {

--- a/crates/brioche-cc/src/main.rs
+++ b/crates/brioche-cc/src/main.rs
@@ -40,15 +40,15 @@ fn run() -> eyre::Result<()> {
         .context("failed to get sysroot path from 'libexec/brioche-cc/sysroot'")?;
 
     let mut args = std::env::args_os();
-    let arg0 = args.next();
-    let args = args.collect::<Vec<_>>();
+    let first_arg = args.next();
+    let next_args = args.collect::<Vec<_>>();
 
     let mut command = std::process::Command::new(&cc);
-    if let Some(arg0) = arg0 {
+    if let Some(arg0) = first_arg {
         command.arg0(&arg0);
     }
 
-    let has_sysroot_arg = args.iter().any(|arg| {
+    let has_sysroot_arg = next_args.iter().any(|arg| {
         let arg_string = arg.to_string_lossy();
         arg_string == "--sysroot" || arg_string.starts_with("--sysroot=")
     });
@@ -57,7 +57,7 @@ fn run() -> eyre::Result<()> {
         command.arg("--sysroot").arg(sysroot_path);
     }
 
-    command.args(&args);
+    command.args(&next_args);
 
     let error = command.exec();
     panic!("brioche-cc exec error: {error:#}");

--- a/crates/runnable-core/src/encoding.rs
+++ b/crates/runnable-core/src/encoding.rs
@@ -27,8 +27,8 @@ where
         let encoded: Cow<'de, str> = serde::de::Deserialize::deserialize(deserializer)?;
         let decoded =
             tick_encoding::decode(encoded.as_bytes()).map_err(serde::de::Error::custom)?;
-        let deserialized = T::try_from(decoded.into_owned()).map_err(serde::de::Error::custom)?;
-        Ok(deserialized)
+
+        T::try_from(decoded.into_owned()).map_err(serde::de::Error::custom)
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86"
+channel = "1.87"
 profile = "default"
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
And workaround the new lint [`pedantic::unnecessary_debug_formatting`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_debug_formatting). Plus, while I was working on resolving the new lints. I re-enabled a lint I had disabled previously, and that was easy to correct.