### PR TITLE
chore: switch to file_type for symlink check

### DIFF
--- a/crates/brioche-autopack/src/lib.rs
+++ b/crates/brioche-autopack/src/lib.rs
@@ -326,7 +326,7 @@ fn autopack_context(config: &AutopackConfig) -> eyre::Result<AutopackContext> {
         for entry in library_path_env_dir_entries {
             let entry = entry?;
             eyre::ensure!(
-                entry.metadata()?.is_symlink(),
+                entry.file_type()?.is_symlink(),
                 "expected {:?} to be a symlink",
                 entry.path()
             );
@@ -355,7 +355,7 @@ fn autopack_context(config: &AutopackConfig) -> eyre::Result<AutopackContext> {
         for entry in path_env_dir_entries {
             let entry = entry?;
             eyre::ensure!(
-                entry.metadata()?.is_symlink(),
+                entry.file_type()?.is_symlink(),
                 "expected {:?} to be a symlink",
                 entry.path()
             );


### PR DESCRIPTION
I did this change for one reason:

<img width="968" alt="image" src="https://github.com/user-attachments/assets/ea264dd3-c48d-459f-bffb-b8513c7e0170" />

The method `is_symlink()` from `metadata()` calls internally `file_type()`. We can remove an indirection here.