### PR TITLE
Update GH Actions workflow to only push to S3 on `main` and `build/*`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+      - 'build/**'
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,16 +42,8 @@ jobs:
       - name: Run tests
         run: cargo test --all --release
 
-  all-checks-passed:
-    name: All checks passed
-    needs: [check, test]
-    runs-on: ubuntu-24.04
-    steps:
-      - run: ":"
-
   build:
     name: Build artifacts [${{ matrix.platform.name }}]
-    if: github.event_name == 'push'
     strategy:
       matrix:
         platform:
@@ -145,10 +140,18 @@ jobs:
           if-no-files-found: error
           path: artifacts/brioche
 
+  all-checks-passed:
+    name: All checks passed
+    needs: [check, test, build]
+    runs-on: ubuntu-24.04
+    steps:
+      - run: ":"
+
   push:
     name: Push artifacts
-    if: github.event_name == 'push' && github.repository == 'brioche-dev/brioche-runtime-utils'
-    needs: [all-checks-passed, build]
+    # Only push artifacts when pushing to `main` and `build/*` branches
+    if: github.event_name == 'push' && github.repository == 'brioche-dev/brioche-runtime-utils' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/'))
+    needs: [all-checks-passed]
     runs-on: ubuntu-24.04
     steps:
       - name: Download artifacts (x86_64-linux)


### PR DESCRIPTION
This PR tweaks the GitHub Actions CI workflow to only try pushing built artifacts to S3 when pushing to the `main` branch or branches starting with `build/`. This is basically the same strategy we use for the `brioche` and `brioche-packages` repos, and should fix issues with Dependabot (e.g. the failure that happened in #34)