### PR TITLE
Update `add_named_blob` to create directory under `aliases` atomically

### DIFF
--- a/crates/brioche-autopack/src/lib.rs
+++ b/crates/brioche-autopack/src/lib.rs
@@ -1043,16 +1043,17 @@ fn add_named_blob_from(
         Path::new(filename)
     };
 
-    let mut file = std::fs::File::open(path)?;
+    let file = std::fs::File::open(path)?;
     let metadata = file.metadata()?;
 
     let permissions = metadata.permissions();
     let mode = permissions.mode();
     let is_executable = mode & 0o111 != 0;
 
+    let file_reader = std::io::BufReader::new(file);
     let resource_path = brioche_resources::add_named_blob(
         &ctx.config.resource_dir,
-        &mut file,
+        file_reader,
         is_executable,
         alias_name,
     )?;

--- a/crates/brioche-packer/src/main.rs
+++ b/crates/brioche-packer/src/main.rs
@@ -240,9 +240,10 @@ fn run_update_source(args: &UpdateSourceArgs) -> eyre::Result<()> {
             let new_source_permissions = new_source.metadata()?.permissions();
             let is_executable = is_executable(&new_source_permissions);
 
+            let new_source_reader = std::io::BufReader::new(new_source);
             let new_source_resource = brioche_resources::add_named_blob(
                 &output_resource_dir,
-                &new_source,
+                new_source_reader,
                 is_executable,
                 new_name,
             )?;

--- a/crates/brioche-strip/src/main.rs
+++ b/crates/brioche-strip/src/main.rs
@@ -438,9 +438,10 @@ fn finish_remapped_file(remapped_file: RemapFile) -> eyre::Result<()> {
                     // Add the temp file as a new resource. We re-use the
                     // original program's name and permissions
                     temp_file.rewind()?;
+                    let temp_file_reader = std::io::BufReader::new(temp_file);
                     let new_source_resource = brioche_resources::add_named_blob(
                         &output_resource_dir,
-                        &mut temp_file,
+                        temp_file_reader,
                         is_executable,
                         program_name,
                     )?;


### PR DESCRIPTION
This PR updates the function `brioche_resources::add_named_blob` to make it so the directories / symlinks of the form `brioche-resources.d/aliases/{name}/{hash}/{name}`  are created atomically. That is, if the `aliases/{name}/{hash}` path exists, then the symlink `aliases/{name}/{hash}/{name}` is also guaranteed to exist, and other processes will never see the path `aliases/{name}/{hash}` as an empty directory.

I made this change to fix what I believe is a rare race condition in `brioche-packed-userland-exec`, which I believe was the cause of the failure in [brioche-packages/Build#300](https://github.com/brioche-dev/brioche-packages/actions/runs/15675027606). Here's my current understanding of the failure: the packed metadata refers to the alias _directory_ (e.g. `aliases/{name}/{hash}/`), not the symlink within that directory. When it tries to resolve it to a concrete path by searching all possible resource dirs, it can sometimes find an empty `aliases/{name}/{hash}` directory before the symlink is created. Then, that (still empty) directory is passed to the dynamic linker as a search path. And sometimes, the dynamic linker will try and search that directory before the symlink gets added, which causes it to fail to load a dynamic library.

Using the commit https://github.com/brioche-dev/brioche-packages/commit/55c972d7d459ca813f06189f204d124669e47487, this command very reliably failed for me _specifically on my 8-core M1 Mac mini running Asahi Linux_:

```sh
brioche build -p packages/nushell
```

(I also tried to reproduce on 2 different aarch64 EC2 instances, but wasn't able to. I also wasn't able to reproduce the issue under `strace`. Tracking this down has been a pain...)