### PR TITLE
Update schemars to latest release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,5 +23,3 @@ updates:
       cargo:
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "schemars"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "globset",
  "goblin 0.10.0",
  "runnable-core",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
  "serde_with",
@@ -953,7 +953,7 @@ dependencies = [
  "bincode",
  "brioche-resources",
  "bstr",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_with",
  "thiserror",
@@ -996,33 +996,22 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1124,8 +1113,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.2.6",
- "schemars 0.8.22",
- "schemars 0.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",

--- a/crates/brioche-packer/Cargo.toml
+++ b/crates/brioche-packer/Cargo.toml
@@ -15,10 +15,10 @@ eyre = "0.6.12"
 globset = "0.4.16"
 goblin = "0.10.0"
 runnable-core = { path = "../runnable-core" }
-schemars = "0.8.22"
+schemars = "0.9.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = { version = "1.0.140" }
-serde_with = { version = "3.13.0", features = ["schemars_0_8"] }
+serde_with = { version = "3.13.0", features = ["schemars_0_9"] }
 walkdir = "2.5.0"
 
 [lints]

--- a/crates/runnable-core/Cargo.toml
+++ b/crates/runnable-core/Cargo.toml
@@ -8,9 +8,9 @@ rust-version.workspace = true
 bincode = "2.0.0-rc.3"
 brioche-resources = { path = "../brioche-resources" }
 bstr = "1.9.1"
-schemars = "0.8.22"
+schemars = "0.9.0"
 serde = { version = "1.0.203", features = ["derive"] }
-serde_with = { version = "3.13.0", features = ["schemars_0_8"] }
+serde_with = { version = "3.13.0", features = ["schemars_0_9"] }
 thiserror = "2.0.11"
 tick-encoding = "0.1.3"
 

--- a/crates/runnable-core/src/encoding.rs
+++ b/crates/runnable-core/src/encoding.rs
@@ -32,12 +32,12 @@ where
     }
 }
 
-impl<T> serde_with::schemars_0_8::JsonSchemaAs<T> for TickEncoded {
-    fn schema_name() -> String {
-        "TickEncoded".to_string()
+impl<T> serde_with::schemars_0_9::JsonSchemaAs<T> for TickEncoded {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("TickEncoded")
     }
 
-    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn json_schema(generator: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
         <String as schemars::JsonSchema>::json_schema(generator)
     }
 }


### PR DESCRIPTION
This PR makes use of the new `schemars` dependency `0.9`. The changes include modifying dependency versions, updating feature flags, and refactoring code to align with the new API introduced in `schemars` 0.9 (https://github.com/jonasbb/serde_with/pull/849).

Thanks to the merge of https://github.com/jaudiger/brioche-runtime-utils/commit/51a8c49dafca2ab1b91a80755eed03799c9cb10b, we can safely remove now the dependency ignore rule from dependabot.