### PR TITLE
ci(rust): update nightly toolchain to nightly-2025-07-01

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  NIGHTLY_TOOLCHAIN: nightly-2025-05-23
+  NIGHTLY_TOOLCHAIN: nightly-2025-07-01
 
 jobs:
   check:


### PR DESCRIPTION
This pull request updates the nightly Rust toolchain version used in the GitHub CI workflow.