### PR TITLE
chore(brioche-autopack): remove a call to `.clone()` that is not necessary in collect_all_library_dirs

### DIFF
--- a/crates/brioche-autopack/src/lib.rs
+++ b/crates/brioche-autopack/src/lib.rs
@@ -930,7 +930,7 @@ fn collect_all_library_dirs(
 
             let is_new_library_path = found_library_dirs.insert(library_resource_dir.clone());
             if is_new_library_path {
-                resource_library_dirs.push(library_resource_dir.clone());
+                resource_library_dirs.push(library_resource_dir);
             }
         }
 


### PR DESCRIPTION
Remove a call to `.clone()` that is not necessary in `collect_all_library_dirs()`. Since the value can be borrowed (this is the last use of the value in the function).