### PR TITLE
chore(clippy): remove clippy large_enum_variant allowances

### DIFF
--- a/crates/brioche-packer/src/main.rs
+++ b/crates/brioche-packer/src/main.rs
@@ -11,7 +11,6 @@ use eyre::{Context as _, OptionExt as _};
 
 mod autopack_template;
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Parser)]
 enum Args {
     Pack {
@@ -135,7 +134,6 @@ fn run() -> eyre::Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Parser)]
 struct AutopackArgs {
     #[arg(long)]


### PR DESCRIPTION
It seems we don't anymore need to whitelist this lint `clippy::large_enum_variant`. I think something changed with `PathBuf` in recent Rust releases.