### PR TITLE
build: update Rust version to 1.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2024"
-rust-version = "1.89" # To align with the rust-toolchain.toml
+rust-version = "1.90" # To align with the rust-toolchain.toml
 
 [workspace]
 members = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89"
+channel = "1.90"
 profile = "default"
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Update Rust to [its latest version 1.90.0](https://doc.rust-lang.org/stable/releases.html) which leads faster build time. There is no new lints detected by Clippy 🚀