### PR TITLE
build: update Rust to 1.95 and nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  NIGHTLY_TOOLCHAIN: nightly-2026-03-15
+  NIGHTLY_TOOLCHAIN: nightly-2026-04-15
   # Default environment variables for Cargo
   CARGO_INCREMENTAL: "0"
   CARGO_PROFILE_DEV_DEBUG: "false"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,6 @@ version = "0.1.1"
 dependencies = [
  "brioche-pack",
  "brioche-resources",
- "cfg-if",
  "libc",
  "thiserror",
  "userland-execve",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 edition = "2024"
-rust-version = "1.94" # To align with the rust-toolchain.toml
+rust-version = "1.95" # To align with the rust-toolchain.toml
 
 [workspace]
 members = [

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -7,7 +7,6 @@ rust-version.workspace = true
 [dependencies]
 brioche-pack = { workspace = true }
 brioche-resources = { path = "../brioche-resources" }
-cfg-if = "1.0.4"
 libc = "0.2.184"
 thiserror = "2.0.18"
 

--- a/crates/brioche-packed-userland-exec/src/main.rs
+++ b/crates/brioche-packed-userland-exec/src/main.rs
@@ -3,8 +3,8 @@
 
 mod linux;
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "linux")] {
+cfg_select! {
+    target_os = "linux" => {
         #[cfg_attr(not(test), unsafe(no_mangle))]
         #[allow(clippy::missing_safety_doc, clippy::similar_names)]
         pub unsafe extern "C" fn main(argc: libc::c_int, argv: *const *const libc::c_char) -> libc::c_int {
@@ -12,7 +12,8 @@ cfg_if::cfg_if! {
                 linux::entrypoint(argc, argv)
             }
         }
-    } else {
+    }
+    _ => {
         fn main() {
             eprintln!("brioche-packed-userland-exec is only supported on Linux");
             std::process::exit(1);

--- a/crates/brioche-strip/src/main.rs
+++ b/crates/brioche-strip/src/main.rs
@@ -385,9 +385,8 @@ fn finish_remapped_file(remapped_file: RemapFile) -> eyre::Result<()> {
             output_path,
         } => {
             // Open the output file
-            let mut output = std::fs::File::create(output_path).with_context(|| {
-                format!("failed to open output {}", temp_file.path().display(),)
-            })?;
+            let mut output = std::fs::File::create(output_path)
+                .with_context(|| format!("failed to open output {}", temp_file.path().display()))?;
 
             // Copy the temp file to the output
             temp_file.rewind()?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"
 profile = "default"
 targets = ["x86_64-unknown-linux-musl"]


### PR DESCRIPTION
This PR updates Rust to 1.95, and it also removes the dependency `cfg-if` thanks to the new stable `cfg_select!` macro.