### PR TITLE
chore: add e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
   test:
     name: Run tests
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04
@@ -47,6 +48,7 @@ jobs:
   build:
     name: Build artifacts [${{ matrix.name }}]
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: x86_64-linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,11 @@ dependencies = [
  "eyre",
  "globset",
  "goblin 0.10.5",
+ "libloading",
  "pathdiff",
  "runnable-core",
  "serde_json",
+ "tempfile",
  "thiserror",
  "walkdir",
 ]
@@ -206,6 +208,7 @@ name = "brioche-cc"
 version = "0.1.0"
 dependencies = [
  "eyre",
+ "tempfile",
 ]
 
 [[package]]
@@ -217,6 +220,8 @@ dependencies = [
  "brioche-resources",
  "chumsky",
  "eyre",
+ "goblin 0.10.5",
+ "tempfile",
  "thiserror",
 ]
 
@@ -237,11 +242,13 @@ dependencies = [
 name = "brioche-packed-plain-exec"
 version = "0.1.1"
 dependencies = [
+ "brioche-autopack",
  "brioche-pack",
  "brioche-resources",
  "libc",
  "runnable-core",
  "serde_json",
+ "tempfile",
  "thiserror",
 ]
 
@@ -249,9 +256,11 @@ dependencies = [
 name = "brioche-packed-userland-exec"
 version = "0.1.1"
 dependencies = [
+ "brioche-autopack",
  "brioche-pack",
  "brioche-resources",
  "libc",
+ "tempfile",
  "thiserror",
  "userland-execve",
 ]
@@ -273,6 +282,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tempfile",
  "walkdir",
 ]
 
@@ -763,6 +773,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/crates/brioche-autopack/Cargo.toml
+++ b/crates/brioche-autopack/Cargo.toml
@@ -16,5 +16,9 @@ serde_json = "1.0.149"
 thiserror = "2.0.18"
 walkdir = "2.5.0"
 
+[dev-dependencies]
+libloading = "0.8"
+tempfile = "3.27.0"
+
 [lints]
 workspace = true

--- a/crates/brioche-autopack/tests/e2e.rs
+++ b/crates/brioche-autopack/tests/e2e.rs
@@ -1,0 +1,96 @@
+//! End-to-end tests for brioche-autopack.
+#![cfg(target_os = "linux")]
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// System library directories likely to hold libc and ld-linux. Filtered
+/// to existing dirs so non-multiarch hosts still resolve a usable subset.
+fn library_search_dirs() -> Vec<PathBuf> {
+    [
+        "/lib/x86_64-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu",
+        "/lib/aarch64-linux-gnu",
+        "/usr/lib/aarch64-linux-gnu",
+        "/lib64",
+        "/usr/lib64",
+        "/lib",
+        "/usr/lib",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .filter(|p| p.is_dir())
+    .collect()
+}
+
+/// Compiles `src` to `output` with the system gcc, forwarding `extra`
+/// flags ahead of the input.
+fn compile_c(src: &Path, output: &Path, extra: &[&str]) {
+    let status = Command::new("gcc")
+        .args(extra)
+        .arg(src)
+        .arg("-o")
+        .arg(output)
+        .status()
+        .expect("run gcc");
+    assert!(status.success(), "gcc exited {:?}", status.code());
+}
+
+/// A shared library passed through autopack gets its pack trailer
+/// appended past the ELF segments, so a well-behaved dynamic loader
+/// dlopens it and resolves its symbols normally.
+#[test]
+fn autopack_shared_library_remains_dlopen_able() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("addlib.c");
+    std::fs::write(
+        &src,
+        "int brioche_test_add(int a, int b) { return a + b; }\n",
+    )
+    .unwrap();
+
+    let lib = tmp.path().join("libbriochetest.so");
+    compile_c(&src, &lib, &["-shared", "-fPIC"]);
+
+    let resource_dir = tmp.path().join("brioche-resources.d");
+    std::fs::create_dir(&resource_dir).unwrap();
+
+    let dynamic_linking = brioche_autopack::DynamicLinkingConfig {
+        library_paths: library_search_dirs(),
+        skip_libraries: HashSet::new(),
+        extra_libraries: vec![],
+        skip_unknown_libraries: true,
+    };
+    brioche_autopack::autopack(
+        brioche_autopack::AutopackInputs::Paths(vec![lib.clone()]),
+        &brioche_autopack::AutopackConfig {
+            resource_dir: resource_dir.clone(),
+            all_resource_dirs: vec![resource_dir],
+            quiet: true,
+            link_dependencies: vec![PathBuf::from("/")],
+            dynamic_binary: None,
+            shared_library: Some(brioche_autopack::SharedLibraryConfig {
+                dynamic_linking,
+                allow_empty: true,
+            }),
+            script: None,
+            repack: None,
+        },
+    )
+    .expect("autopack");
+
+    brioche_pack::extract_pack(std::fs::File::open(&lib).unwrap())
+        .expect("autopack must inject pack trailer");
+
+    // SAFETY: the loaded library defines a pure, well-typed function with no
+    // global state; calling it is safe.
+    unsafe {
+        let library = libloading::Library::new(&lib).expect("dlopen");
+        let func: libloading::Symbol<unsafe extern "C" fn(i32, i32) -> i32> = library
+            .get(b"brioche_test_add\0")
+            .expect("symbol brioche_test_add");
+        assert_eq!(func(2, 3), 5);
+        assert_eq!(func(-7, 7), 0);
+    }
+}

--- a/crates/brioche-cc/Cargo.toml
+++ b/crates/brioche-cc/Cargo.toml
@@ -7,5 +7,8 @@ rust-version.workspace = true
 [dependencies]
 eyre = "0.6.12"
 
+[dev-dependencies]
+tempfile = "3.27.0"
+
 [lints]
 workspace = true

--- a/crates/brioche-cc/tests/e2e.rs
+++ b/crates/brioche-cc/tests/e2e.rs
@@ -1,0 +1,149 @@
+//! End-to-end tests for brioche-cc.
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Cargo-built brioche-cc binary under test.
+const BRIOCHE_CC: &str = env!("CARGO_BIN_EXE_brioche-cc");
+
+/// Inner cc stand-in. Records each argv entry on its own line in
+/// `$BRIOCHE_CC_TEST_ARGS` and exits with `$BRIOCHE_CC_TEST_EXIT`
+/// (default 0), letting tests inspect what the wrapper passed through.
+const RECORDING_INNER_CC: &str = "#!/bin/sh\n\
+    set -e\n\
+    out_file=\"$BRIOCHE_CC_TEST_ARGS\"\n\
+    : > \"$out_file\"\n\
+    for arg in \"$@\"; do\n\
+        printf '%s\\n' \"$arg\" >> \"$out_file\"\n\
+    done\n\
+    exit \"${BRIOCHE_CC_TEST_EXIT:-0}\"\n";
+
+/// Lays out the `bin`, `libexec/brioche-cc`, and a real `sysroot` dir
+/// the wrapper requires, installs `inner_cc_script` as the inner `cc`,
+/// and returns `(wrapper, sysroot)` where `sysroot` is the canonical
+/// path the wrapper will inject as `--sysroot`.
+fn setup_cc_harness(tmp: &Path, inner_cc_script: &str) -> (PathBuf, PathBuf) {
+    let bin = tmp.join("bin");
+    let libexec = tmp.join("libexec").join("brioche-cc");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::create_dir_all(&libexec).unwrap();
+
+    let sysroot = libexec.join("sysroot");
+    std::fs::create_dir(&sysroot).unwrap();
+    let sysroot = sysroot.canonicalize().unwrap();
+
+    let wrapper = bin.join("cc");
+    std::fs::copy(BRIOCHE_CC, &wrapper).unwrap();
+
+    let inner_cc = libexec.join("cc");
+    std::fs::write(&inner_cc, inner_cc_script).unwrap();
+    let mut perms = std::fs::metadata(&inner_cc).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&inner_cc, perms).unwrap();
+
+    (wrapper, sysroot)
+}
+
+/// Reads the recorded argv file written by [`RECORDING_INNER_CC`].
+fn read_recorded_args(path: &Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .unwrap()
+        .lines()
+        .map(str::to_owned)
+        .collect()
+}
+
+/// When the user does not pass `--sysroot`, the wrapper injects
+/// `--sysroot <path>` before forwarding the rest of argv.
+#[test]
+fn brioche_cc_injects_sysroot_when_absent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (wrapper, sysroot) = setup_cc_harness(tmp.path(), RECORDING_INNER_CC);
+    let args_log = tmp.path().join("args.log");
+
+    let status = Command::new(&wrapper)
+        .arg("-c")
+        .arg("foo.c")
+        .env("BRIOCHE_CC_TEST_ARGS", &args_log)
+        .status()
+        .expect("run brioche-cc");
+    assert!(
+        status.success(),
+        "brioche-cc exited unsuccessfully: {:?}",
+        status.code()
+    );
+
+    assert_eq!(
+        read_recorded_args(&args_log),
+        vec![
+            "--sysroot".to_owned(),
+            sysroot.to_string_lossy().into_owned(),
+            "-c".to_owned(),
+            "foo.c".to_owned(),
+        ],
+    );
+}
+
+/// When the user passes their own `--sysroot` (in either spaced or
+/// `=`-joined form), the wrapper forwards argv unchanged and does not
+/// inject a second `--sysroot`.
+#[test]
+fn brioche_cc_preserves_user_sysroot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (wrapper, _sysroot) = setup_cc_harness(tmp.path(), RECORDING_INNER_CC);
+    let args_log = tmp.path().join("args.log");
+
+    let status = Command::new(&wrapper)
+        .arg("--sysroot")
+        .arg("/custom-sysroot")
+        .arg("foo.c")
+        .env("BRIOCHE_CC_TEST_ARGS", &args_log)
+        .status()
+        .expect("run brioche-cc");
+    assert!(
+        status.success(),
+        "brioche-cc exited unsuccessfully: {:?}",
+        status.code()
+    );
+    assert_eq!(
+        read_recorded_args(&args_log),
+        vec![
+            "--sysroot".to_owned(),
+            "/custom-sysroot".to_owned(),
+            "foo.c".to_owned(),
+        ],
+    );
+
+    let status = Command::new(&wrapper)
+        .arg("--sysroot=/custom-sysroot")
+        .arg("foo.c")
+        .env("BRIOCHE_CC_TEST_ARGS", &args_log)
+        .status()
+        .expect("run brioche-cc");
+    assert!(
+        status.success(),
+        "brioche-cc exited unsuccessfully: {:?}",
+        status.code()
+    );
+    assert_eq!(
+        read_recorded_args(&args_log),
+        vec!["--sysroot=/custom-sysroot".to_owned(), "foo.c".to_owned()],
+    );
+}
+
+/// The wrapper exec-replaces itself with the inner cc, so the inner
+/// cc's exit code surfaces as the wrapper's exit code.
+#[test]
+fn brioche_cc_forwards_exit_code() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (wrapper, _sysroot) = setup_cc_harness(tmp.path(), RECORDING_INNER_CC);
+    let args_log = tmp.path().join("args.log");
+
+    let status = Command::new(&wrapper)
+        .arg("foo.c")
+        .env("BRIOCHE_CC_TEST_ARGS", &args_log)
+        .env("BRIOCHE_CC_TEST_EXIT", "7")
+        .status()
+        .expect("run brioche-cc");
+    assert_eq!(status.code(), Some(7));
+}

--- a/crates/brioche-ld/Cargo.toml
+++ b/crates/brioche-ld/Cargo.toml
@@ -12,5 +12,9 @@ chumsky = "0.12.0"
 eyre = "0.6.12"
 thiserror = "2.0.18"
 
+[dev-dependencies]
+goblin = "0.10.5"
+tempfile = "3.27.0"
+
 [lints]
 workspace = true

--- a/crates/brioche-ld/tests/e2e.rs
+++ b/crates/brioche-ld/tests/e2e.rs
@@ -1,0 +1,193 @@
+//! End-to-end tests for brioche-ld.
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Cargo-built brioche-ld binary under test.
+const BRIOCHE_LD: &str = env!("CARGO_BIN_EXE_brioche-ld");
+
+/// Inner ld stand-in for pass-through paths. Writes [`MARKER_BODY`]
+/// to its `-o` target, proving the wrapper invoked it.
+const MARKER_INNER_LD: &str = "#!/bin/sh\n\
+    set -e\n\
+    while [ $# -gt 0 ]; do\n\
+        case \"$1\" in\n\
+            -o) shift; printf 'LINKED' > \"$1\"; shift ;;\n\
+            -o*) printf 'LINKED' > \"${1#-o}\"; shift ;;\n\
+            *) shift ;;\n\
+        esac\n\
+    done\n";
+
+/// Bytes [`MARKER_INNER_LD`] writes to its target.
+const MARKER_BODY: &[u8] = b"LINKED";
+
+/// Lays out the `bin` and `libexec/brioche-ld` siblings the wrapper
+/// expects, installs `inner_ld_script` as the inner `ld`, and returns
+/// the wrapper path callers should invoke.
+fn setup_ld_harness(tmp: &Path, inner_ld_script: &str) -> PathBuf {
+    let bin = tmp.join("bin");
+    let libexec = tmp.join("libexec").join("brioche-ld");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::create_dir_all(&libexec).unwrap();
+
+    let wrapper = bin.join("ld");
+    std::fs::copy(BRIOCHE_LD, &wrapper).unwrap();
+
+    let inner_ld = libexec.join("ld");
+    std::fs::write(&inner_ld, inner_ld_script).unwrap();
+    let mut perms = std::fs::metadata(&inner_ld).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&inner_ld, perms).unwrap();
+
+    wrapper
+}
+
+/// System library directories likely to hold libc and ld-linux. Filtered
+/// to existing dirs so non-multiarch hosts still resolve a usable subset.
+#[cfg(target_os = "linux")]
+fn library_search_dirs() -> Vec<PathBuf> {
+    [
+        "/lib/x86_64-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu",
+        "/lib/aarch64-linux-gnu",
+        "/usr/lib/aarch64-linux-gnu",
+        "/lib64",
+        "/usr/lib64",
+        "/lib",
+        "/usr/lib",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .filter(|p| p.is_dir())
+    .collect()
+}
+
+/// Pass-through mode skips autopack: the wrapper invokes the inner
+/// linker and leaves its output bytes untouched.
+#[test]
+fn brioche_ld_passthrough_preserves_inner_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    let wrapper = setup_ld_harness(tmp.path(), MARKER_INNER_LD);
+
+    let output = tmp.path().join("a.out");
+
+    let status = Command::new(&wrapper)
+        .arg("-o")
+        .arg(&output)
+        .arg("dummy.o")
+        .env("BRIOCHE_LD_AUTOPACK", "false")
+        .status()
+        .expect("run brioche-ld");
+    assert!(
+        status.success(),
+        "brioche-ld exited unsuccessfully: {:?}",
+        status.code()
+    );
+
+    assert_eq!(std::fs::read(&output).unwrap(), MARKER_BODY);
+}
+
+/// Pass-through mode propagates the inner linker's exit code unchanged.
+#[test]
+fn brioche_ld_passthrough_forwards_exit_code() {
+    let tmp = tempfile::tempdir().unwrap();
+    let wrapper = setup_ld_harness(tmp.path(), "#!/bin/sh\nexit 7\n");
+
+    let output = tmp.path().join("a.out");
+
+    let status = Command::new(&wrapper)
+        .arg("-o")
+        .arg(&output)
+        .arg("dummy.o")
+        .env("BRIOCHE_LD_AUTOPACK", "false")
+        .status()
+        .expect("run brioche-ld");
+    assert_eq!(status.code(), Some(7));
+}
+
+/// The wrapper invokes the inner linker, which emits a real ELF,
+/// then autopacks the output so its trailer extracts as an `LdLinux`
+/// pack.
+#[cfg(target_os = "linux")]
+#[test]
+fn brioche_ld_autopacks_its_output() {
+    let target_bin_dir = Path::new(BRIOCHE_LD).parent().expect("brioche-ld parent");
+    let packed_runtime = target_bin_dir.join("brioche-packed-plain-exec");
+    assert!(
+        packed_runtime.is_file(),
+        "brioche-packed-plain-exec missing at {} (run cargo test --workspace)",
+        packed_runtime.display(),
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    let src = tmp.path().join("hello.c");
+    std::fs::write(&src, "int main(void){return 0;}\n").unwrap();
+    let prebuilt = tmp.path().join("prebuilt");
+    let gcc_status = Command::new("gcc")
+        .arg(&src)
+        .arg("-o")
+        .arg(&prebuilt)
+        .status()
+        .expect("run gcc");
+    assert!(gcc_status.success(), "gcc exited {:?}", gcc_status.code());
+
+    let inner_ld_script = format!(
+        "#!/bin/sh\n\
+         set -e\n\
+         out=\n\
+         while [ $# -gt 0 ]; do\n\
+             case \"$1\" in\n\
+                 -o) shift; out=\"$1\"; shift ;;\n\
+                 -o*) out=\"${{1#-o}}\"; shift ;;\n\
+                 *) shift ;;\n\
+             esac\n\
+         done\n\
+         if [ -z \"$out\" ]; then exit 1; fi\n\
+         cp \"{}\" \"$out\"\n",
+        prebuilt.to_string_lossy(),
+    );
+    let wrapper = setup_ld_harness(tmp.path(), &inner_ld_script);
+
+    let ld_resource_dir = tmp.path().join("libexec").join("brioche-ld");
+    let runtime_link = ld_resource_dir.join("brioche-packed");
+    std::os::unix::fs::symlink(&packed_runtime, &runtime_link).unwrap();
+
+    let prebuilt_bytes = std::fs::read(&prebuilt).unwrap();
+    let elf = goblin::elf::Elf::parse(&prebuilt_bytes).expect("parse prebuilt ELF");
+    let interpreter = elf
+        .interpreter
+        .expect("prebuilt must have a dynamic interpreter");
+    let rel_interpreter = Path::new(interpreter)
+        .strip_prefix("/")
+        .expect("interpreter path must be absolute");
+    let staged_interpreter = ld_resource_dir.join(rel_interpreter);
+    std::fs::create_dir_all(staged_interpreter.parent().unwrap()).unwrap();
+    std::fs::copy(interpreter, &staged_interpreter).unwrap();
+
+    let output_bin = tmp.path().join("output").join("bin");
+    std::fs::create_dir_all(&output_bin).unwrap();
+    std::fs::create_dir(tmp.path().join("brioche-resources.d")).unwrap();
+    let output = output_bin.join("hello");
+
+    let mut command = Command::new(&wrapper);
+    command.arg("-o").arg(&output);
+    for lib_dir in library_search_dirs() {
+        command.arg("-L").arg(lib_dir);
+    }
+    command.arg("dummy.o");
+    let status = command.status().expect("run brioche-ld");
+    assert!(
+        status.success(),
+        "brioche-ld exited unsuccessfully: {:?}",
+        status.code()
+    );
+
+    let extracted = brioche_pack::extract_pack(std::fs::File::open(&output).unwrap())
+        .expect("pack trailer must be present in output");
+    assert!(
+        matches!(extracted.pack, brioche_pack::Pack::LdLinux { .. }),
+        "expected LdLinux pack, got {:?}",
+        extracted.pack,
+    );
+}

--- a/crates/brioche-packed-plain-exec/Cargo.toml
+++ b/crates/brioche-packed-plain-exec/Cargo.toml
@@ -12,5 +12,9 @@ runnable-core = { path = "../runnable-core" }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
 
+[dev-dependencies]
+brioche-autopack = { path = "../brioche-autopack" }
+tempfile = "3.27.0"
+
 [lints]
 workspace = true

--- a/crates/brioche-packed-plain-exec/tests/e2e.rs
+++ b/crates/brioche-packed-plain-exec/tests/e2e.rs
@@ -1,0 +1,114 @@
+//! End-to-end tests for brioche-packed-plain-exec.
+#![cfg(target_os = "linux")]
+
+use std::collections::HashSet;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Cargo-built brioche-packed-plain-exec binary under test.
+const PACKED_PLAIN_EXEC: &str = env!("CARGO_BIN_EXE_brioche-packed-plain-exec");
+
+/// System library directories likely to hold libc and ld-linux. Filtered
+/// to existing dirs so non-multiarch hosts still resolve a usable subset.
+fn library_search_dirs() -> Vec<PathBuf> {
+    [
+        "/lib/x86_64-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu",
+        "/lib/aarch64-linux-gnu",
+        "/usr/lib/aarch64-linux-gnu",
+        "/lib64",
+        "/usr/lib64",
+        "/lib",
+        "/usr/lib",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .filter(|p| p.is_dir())
+    .collect()
+}
+
+/// Compiles `src` to `output` with the system gcc.
+fn compile_c(src: &Path, output: &Path) {
+    let status = Command::new("gcc")
+        .arg(src)
+        .arg("-o")
+        .arg(output)
+        .status()
+        .expect("run gcc");
+    assert!(status.success(), "gcc exited {:?}", status.code());
+}
+
+/// Lays out the `bin` and sibling `brioche-resources.d` the runtime's
+/// directory walk requires, and returns `(output_path, resource_dir)`.
+fn setup_packed_layout(tmp: &Path, exe_name: &str) -> (PathBuf, PathBuf) {
+    let root = tmp.join("root");
+    let bin_dir = root.join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let resource_dir = root.join("brioche-resources.d");
+    std::fs::create_dir(&resource_dir).unwrap();
+    (bin_dir.join(exe_name), resource_dir)
+}
+
+/// Autopacks `binary` in place as a dynamic executable that defers to the
+/// brioche-packed-plain-exec runtime under test, then restores exec bits
+/// (autopack writes via `File::create`, which honors umask).
+fn autopack_dynamic(binary: &Path, resource_dir: &Path) {
+    let dynamic_linking = brioche_autopack::DynamicLinkingConfig {
+        library_paths: library_search_dirs(),
+        skip_libraries: HashSet::new(),
+        extra_libraries: vec![],
+        skip_unknown_libraries: true,
+    };
+    brioche_autopack::autopack(
+        brioche_autopack::AutopackInputs::Paths(vec![binary.to_path_buf()]),
+        &brioche_autopack::AutopackConfig {
+            resource_dir: resource_dir.to_path_buf(),
+            all_resource_dirs: vec![resource_dir.to_path_buf()],
+            quiet: true,
+            link_dependencies: vec![PathBuf::from("/")],
+            dynamic_binary: Some(brioche_autopack::DynamicBinaryConfig {
+                packed_executable: PathBuf::from(PACKED_PLAIN_EXEC),
+                extra_runtime_library_paths: vec![],
+                dynamic_linking,
+            }),
+            shared_library: None,
+            script: None,
+            repack: None,
+        },
+    )
+    .expect("autopack");
+
+    let mut perms = std::fs::metadata(binary).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(binary, perms).unwrap();
+}
+
+/// A dynamic binary packed via autopack, when invoked, runs through the
+/// brioche-packed-plain-exec runtime: stdout from the underlying program
+/// is preserved and its exit code surfaces as the packed exit code.
+#[test]
+fn packed_dynamic_binary_executes_through_runtime() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("hello.c");
+    std::fs::write(
+        &src,
+        "#include <stdio.h>\n\
+         int main(void){ printf(\"hello-from-packed\\n\"); return 17; }\n",
+    )
+    .unwrap();
+
+    let (output, resource_dir) = setup_packed_layout(tmp.path(), "hello");
+    compile_c(&src, &output);
+    autopack_dynamic(&output, &resource_dir);
+
+    let run = Command::new(&output).output().expect("run packed");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&run.stderr).into_owned();
+    assert_eq!(
+        run.status.code(),
+        Some(17),
+        "exit code mismatch; stdout={stdout} stderr={stderr}",
+    );
+    assert!(stdout.contains("hello-from-packed"), "stdout={stdout}");
+}

--- a/crates/brioche-packed-userland-exec/Cargo.toml
+++ b/crates/brioche-packed-userland-exec/Cargo.toml
@@ -13,5 +13,9 @@ thiserror = "2.0.18"
 [target.'cfg(target_os = "linux")'.dependencies]
 userland-execve = "0.2.0"
 
+[dev-dependencies]
+brioche-autopack = { path = "../brioche-autopack" }
+tempfile = "3.27.0"
+
 [lints]
 workspace = true

--- a/crates/brioche-packed-userland-exec/tests/e2e.rs
+++ b/crates/brioche-packed-userland-exec/tests/e2e.rs
@@ -1,0 +1,117 @@
+//! End-to-end tests for brioche-packed-userland-exec.
+#![cfg(target_os = "linux")]
+
+use std::collections::HashSet;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Cargo-built brioche-packed-userland-exec binary under test.
+const PACKED_USERLAND_EXEC: &str = env!("CARGO_BIN_EXE_brioche-packed-userland-exec");
+
+/// System library directories likely to hold libc and ld-linux. Filtered
+/// to existing dirs so non-multiarch hosts still resolve a usable subset.
+fn library_search_dirs() -> Vec<PathBuf> {
+    [
+        "/lib/x86_64-linux-gnu",
+        "/usr/lib/x86_64-linux-gnu",
+        "/lib/aarch64-linux-gnu",
+        "/usr/lib/aarch64-linux-gnu",
+        "/lib64",
+        "/usr/lib64",
+        "/lib",
+        "/usr/lib",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .filter(|p| p.is_dir())
+    .collect()
+}
+
+/// Compiles `src` to `output` with the system gcc.
+fn compile_c(src: &Path, output: &Path) {
+    let status = Command::new("gcc")
+        .arg(src)
+        .arg("-o")
+        .arg(output)
+        .status()
+        .expect("run gcc");
+    assert!(status.success(), "gcc exited {:?}", status.code());
+}
+
+/// Lays out the `bin` and sibling `brioche-resources.d` the runtime's
+/// directory walk requires, and returns `(output_path, resource_dir)`.
+fn setup_packed_layout(tmp: &Path, exe_name: &str) -> (PathBuf, PathBuf) {
+    let root = tmp.join("root");
+    let bin_dir = root.join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let resource_dir = root.join("brioche-resources.d");
+    std::fs::create_dir(&resource_dir).unwrap();
+    (bin_dir.join(exe_name), resource_dir)
+}
+
+/// Autopacks `binary` in place as a dynamic executable that defers to the
+/// brioche-packed-userland-exec runtime under test, then restores exec bits
+/// (autopack writes via `File::create`, which honors umask).
+fn autopack_dynamic(binary: &Path, resource_dir: &Path) {
+    let dynamic_linking = brioche_autopack::DynamicLinkingConfig {
+        library_paths: library_search_dirs(),
+        skip_libraries: HashSet::new(),
+        extra_libraries: vec![],
+        skip_unknown_libraries: true,
+    };
+    brioche_autopack::autopack(
+        brioche_autopack::AutopackInputs::Paths(vec![binary.to_path_buf()]),
+        &brioche_autopack::AutopackConfig {
+            resource_dir: resource_dir.to_path_buf(),
+            all_resource_dirs: vec![resource_dir.to_path_buf()],
+            quiet: true,
+            link_dependencies: vec![PathBuf::from("/")],
+            dynamic_binary: Some(brioche_autopack::DynamicBinaryConfig {
+                packed_executable: PathBuf::from(PACKED_USERLAND_EXEC),
+                extra_runtime_library_paths: vec![],
+                dynamic_linking,
+            }),
+            shared_library: None,
+            script: None,
+            repack: None,
+        },
+    )
+    .expect("autopack");
+
+    let mut perms = std::fs::metadata(binary).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(binary, perms).unwrap();
+}
+
+/// A dynamic binary packed via autopack, when invoked, runs through the
+/// brioche-packed-userland-exec runtime: stdout from the underlying program
+/// is preserved and its exit code surfaces as the packed exit code.
+#[test]
+fn packed_dynamic_binary_executes_through_userland_runtime() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("hello.c");
+    std::fs::write(
+        &src,
+        "#include <stdio.h>\n\
+         int main(void){ printf(\"hello-from-userland-packed\\n\"); return 23; }\n",
+    )
+    .unwrap();
+
+    let (output, resource_dir) = setup_packed_layout(tmp.path(), "hello");
+    compile_c(&src, &output);
+    autopack_dynamic(&output, &resource_dir);
+
+    let run = Command::new(&output).output().expect("run packed");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&run.stderr).into_owned();
+    assert_eq!(
+        run.status.code(),
+        Some(23),
+        "exit code mismatch; stdout={stdout} stderr={stderr}",
+    );
+    assert!(
+        stdout.contains("hello-from-userland-packed"),
+        "stdout={stdout}"
+    );
+}

--- a/crates/brioche-packer/Cargo.toml
+++ b/crates/brioche-packer/Cargo.toml
@@ -20,5 +20,8 @@ serde_json = { version = "1.0.149" }
 serde_with = { version = "3.18.0", features = ["schemars_1"] }
 walkdir = "2.5.0"
 
+[dev-dependencies]
+tempfile = "3.27.0"
+
 [lints]
 workspace = true

--- a/crates/brioche-packer/tests/e2e.rs
+++ b/crates/brioche-packer/tests/e2e.rs
@@ -1,0 +1,116 @@
+//! End-to-end tests for brioche-packer.
+use std::io::Read as _;
+use std::path::Path;
+use std::process::Command;
+
+/// Cargo-built brioche-packer binary under test.
+const BRIOCHE_PACKER: &str = env!("CARGO_BIN_EXE_brioche-packer");
+
+/// Minimal `Pack::Static` fixture with two library-dir aliases.
+fn static_pack() -> brioche_pack::Pack {
+    brioche_pack::Pack::Static {
+        library_dirs: vec![b"alias-dir-a".to_vec(), b"alias-dir-b".to_vec()],
+    }
+}
+
+/// Writes `body` to `path`, then appends `pack` as a brioche-pack trailer.
+fn write_packed(path: &Path, body: &[u8], pack: &brioche_pack::Pack) {
+    std::fs::write(path, body).unwrap();
+    let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+    brioche_pack::inject_pack(&mut file, pack).unwrap();
+}
+
+/// Reads the first `len` bytes of `path`.
+fn read_prefix(path: &Path, len: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; len];
+    std::fs::File::open(path)
+        .unwrap()
+        .read_exact(&mut buf)
+        .unwrap();
+    buf
+}
+
+/// `pack` copies the body of `--packed` into `--output` and appends the
+/// trailer described by `--pack`. The body bytes survive the copy and the
+/// trailer round-trips through `extract_pack`.
+#[test]
+fn brioche_packer_pack_writes_trailer_onto_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let body_path = tmp.path().join("body.bin");
+    let body = b"plain-body-bytes";
+    std::fs::write(&body_path, body).unwrap();
+
+    let pack = static_pack();
+    let pack_json = serde_json::to_string(&pack).unwrap();
+    let output = tmp.path().join("packed.bin");
+
+    let status = Command::new(BRIOCHE_PACKER)
+        .arg("pack")
+        .arg("--packed")
+        .arg(&body_path)
+        .arg("--output")
+        .arg(&output)
+        .arg("--pack")
+        .arg(&pack_json)
+        .status()
+        .expect("run brioche-packer pack");
+    assert!(
+        status.success(),
+        "brioche-packer pack exited {:?}",
+        status.code()
+    );
+
+    let extracted = brioche_pack::extract_pack(std::fs::File::open(&output).unwrap())
+        .expect("pack trailer must be present");
+    assert_eq!(format!("{:?}", extracted.pack), format!("{:?}", pack));
+    assert_eq!(extracted.unpacked_len, body.len());
+    assert_eq!(read_prefix(&output, body.len()), body);
+}
+
+/// `read` extracts the trailer of an already-packed file and prints it as
+/// JSON; deserializing that JSON recovers the original pack.
+#[test]
+fn brioche_packer_read_emits_pack_as_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let target = tmp.path().join("target.bin");
+    let pack = static_pack();
+    write_packed(&target, b"unpacked-body-bytes", &pack);
+
+    let output = Command::new(BRIOCHE_PACKER)
+        .arg("read")
+        .arg(&target)
+        .output()
+        .expect("run brioche-packer read");
+    assert!(
+        output.status.success(),
+        "brioche-packer read exited {:?}; stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let parsed: brioche_pack::Pack =
+        serde_json::from_slice(&output.stdout).expect("read output must be valid Pack JSON");
+    assert_eq!(format!("{parsed:?}"), format!("{pack:?}"));
+}
+
+/// `autopack --schema` emits the JSON Schema for the autopack config
+/// template. Consumers parse it as JSON, so the output must at least be a
+/// valid JSON object.
+#[test]
+fn brioche_packer_autopack_schema_is_valid_json() {
+    let output = Command::new(BRIOCHE_PACKER)
+        .arg("autopack")
+        .arg("--schema")
+        .output()
+        .expect("run brioche-packer autopack --schema");
+    assert!(
+        output.status.success(),
+        "brioche-packer autopack --schema exited {:?}; stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("schema output must be valid JSON");
+    assert!(value.is_object(), "schema must be a JSON object");
+}

--- a/crates/brioche-strip/tests/e2e.rs
+++ b/crates/brioche-strip/tests/e2e.rs
@@ -1,0 +1,160 @@
+//! End-to-end tests for brioche-strip.
+use std::io::Read as _;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Cargo-built brioche-strip binary under test.
+const BRIOCHE_STRIP: &str = env!("CARGO_BIN_EXE_brioche-strip");
+
+/// Inner strip stand-in. Truncates each positional arg down to
+/// [`MARKER_BODY`], proving the wrapper invoked strip on its remapped
+/// temp file rather than no-oping.
+const MARKER_INNER_STRIP: &str = "#!/bin/sh\n\
+    set -e\n\
+    for arg in \"$@\"; do\n\
+        case \"$arg\" in\n\
+            -*) ;;\n\
+            *) printf 'STRIPPED' > \"$arg\" ;;\n\
+        esac\n\
+    done\n";
+
+/// Bytes [`MARKER_INNER_STRIP`] writes to its target file.
+const MARKER_BODY: &[u8] = b"STRIPPED";
+
+/// Lays out the `bin` and `libexec/brioche-strip` siblings the wrapper
+/// expects, installs `inner_strip_script` as the inner `strip`, and
+/// returns the wrapper path callers should invoke.
+fn setup_strip_harness(tmp: &Path, inner_strip_script: &str) -> PathBuf {
+    let bin = tmp.join("bin");
+    let libexec = tmp.join("libexec").join("brioche-strip");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::create_dir_all(&libexec).unwrap();
+
+    let wrapper = bin.join("brioche-strip");
+    std::fs::copy(BRIOCHE_STRIP, &wrapper).unwrap();
+
+    let inner_strip = libexec.join("strip");
+    std::fs::write(&inner_strip, inner_strip_script).unwrap();
+    let mut perms = std::fs::metadata(&inner_strip).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&inner_strip, perms).unwrap();
+
+    wrapper
+}
+
+/// Writes `body` to `path`, then appends `pack` as a brioche-pack trailer.
+fn write_packed(path: &Path, body: &[u8], pack: &brioche_pack::Pack) {
+    std::fs::write(path, body).unwrap();
+    let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+    brioche_pack::inject_pack(&mut file, pack).unwrap();
+}
+
+/// Minimal `Pack::Static` fixture with two library-dir aliases.
+fn static_pack() -> brioche_pack::Pack {
+    brioche_pack::Pack::Static {
+        library_dirs: vec![b"alias-dir-a".to_vec(), b"alias-dir-b".to_vec()],
+    }
+}
+
+/// Reads the first `len` bytes of `path`.
+fn read_prefix(path: &Path, len: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; len];
+    std::fs::File::open(path)
+        .unwrap()
+        .read_exact(&mut buf)
+        .unwrap();
+    buf
+}
+
+/// In-place strip preserves the pack trailer: the wrapper hands the
+/// unpacked body to the inner strip and re-emits the file with the
+/// original trailer on top of strip's output.
+#[test]
+fn brioche_strip_preserves_pack_trailer_in_place() {
+    let tmp = tempfile::tempdir().unwrap();
+    let wrapper = setup_strip_harness(tmp.path(), MARKER_INNER_STRIP);
+
+    let target = tmp.path().join("target.bin");
+    let pack = static_pack();
+    write_packed(&target, b"unpacked-body-bytes", &pack);
+
+    let resource_dir = tmp.path().join("brioche-resources.d");
+    std::fs::create_dir(&resource_dir).unwrap();
+
+    let status = Command::new(&wrapper)
+        .arg(&target)
+        .env("BRIOCHE_RESOURCE_DIR", &resource_dir)
+        .status()
+        .expect("run brioche-strip");
+    assert!(
+        status.success(),
+        "brioche-strip exited unsuccessfully: {:?}",
+        status.code()
+    );
+
+    let extracted = brioche_pack::extract_pack(std::fs::File::open(&target).unwrap())
+        .expect("pack trailer must still be present after strip");
+    assert_eq!(format!("{:?}", extracted.pack), format!("{:?}", pack));
+
+    assert_eq!(extracted.unpacked_len, MARKER_BODY.len());
+    assert_eq!(read_prefix(&target, MARKER_BODY.len()), MARKER_BODY);
+}
+
+/// Strip with `-o` preserves the pack trailer on the output and leaves
+/// the input file untouched.
+#[test]
+fn brioche_strip_preserves_pack_trailer_with_output_arg() {
+    let tmp = tempfile::tempdir().unwrap();
+    let wrapper = setup_strip_harness(tmp.path(), MARKER_INNER_STRIP);
+
+    let input = tmp.path().join("input.bin");
+    let pack = static_pack();
+    write_packed(&input, b"unpacked-body-bytes", &pack);
+    let original_input = std::fs::read(&input).unwrap();
+
+    let resource_dir = tmp.path().join("brioche-resources.d");
+    std::fs::create_dir(&resource_dir).unwrap();
+    let output = tmp.path().join("output.bin");
+
+    let status = Command::new(&wrapper)
+        .arg("-o")
+        .arg(&output)
+        .arg(&input)
+        .env("BRIOCHE_RESOURCE_DIR", &resource_dir)
+        .status()
+        .expect("run brioche-strip");
+    assert!(
+        status.success(),
+        "brioche-strip exited unsuccessfully: {:?}",
+        status.code()
+    );
+
+    assert_eq!(std::fs::read(&input).unwrap(), original_input);
+
+    let extracted = brioche_pack::extract_pack(std::fs::File::open(&output).unwrap())
+        .expect("pack trailer must be present in output");
+    assert_eq!(format!("{:?}", extracted.pack), format!("{:?}", pack));
+
+    assert_eq!(extracted.unpacked_len, MARKER_BODY.len());
+    assert_eq!(read_prefix(&output, MARKER_BODY.len()), MARKER_BODY);
+}
+
+/// Pass-through mode bypasses pack handling and propagates the inner
+/// strip's exit code unchanged. The target file's contents do not
+/// matter; nothing reads them.
+#[test]
+fn brioche_strip_passthrough_forwards_exit_code() {
+    let tmp = tempfile::tempdir().unwrap();
+    let wrapper = setup_strip_harness(tmp.path(), "#!/bin/sh\nexit 7\n");
+
+    let target = tmp.path().join("target.bin");
+    std::fs::write(&target, b"plain-content").unwrap();
+
+    let status = Command::new(&wrapper)
+        .arg(&target)
+        .env("BRIOCHE_STRIP_AUTOPACK", "false")
+        .status()
+        .expect("run brioche-strip");
+    assert_eq!(status.code(), Some(7));
+}


### PR DESCRIPTION
This PR adds some end-to-end tests for the binaries of brioche-runtime-utils. These tests do not bring full coverage of the features exposed by those tools, but rather focus on smoking tests. They will not prevent major regression, but that will be a good foundation for upcoming works to at least add initial detection of broken features.